### PR TITLE
Add iconv and multibyte support

### DIFF
--- a/extension/CRM/Banking/PluginImpl/Importer/CSV.php
+++ b/extension/CRM/Banking/PluginImpl/Importer/CSV.php
@@ -141,7 +141,13 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
       if (isset($config->encoding)) {
         $decoded_line = array();
         foreach ($line as $item) {
-          array_push($decoded_line, mb_convert_encoding($item, mb_internal_encoding(), $config->encoding));
+          if (in_array($config->encoding, mb_list_encodings())) {
+            array_push($decoded_line, mb_convert_encoding($item, mb_internal_encoding(), $config->encoding));
+          } else if (extension_loaded('iconv')) {
+            array_push($decoded_line, iconv($config->encoding, mb_internal_encoding(), $item));
+          } else {
+            trigger_error("Unknown encoding {$config->encoding}, try enabling the iconv PHP extension", E_USER_ERROR);
+          }
         }
         $line = $decoded_line;
       }

--- a/extension/CRM/Banking/PluginImpl/Importer/Fixed.php
+++ b/extension/CRM/Banking/PluginImpl/Importer/Fixed.php
@@ -241,7 +241,7 @@ class CRM_Banking_PluginImpl_Importer_Fixed extends CRM_Banking_PluginModel_Impo
           // TODO: error handling
         }
 
-        $value = substr($line, $pos_from-1, $length);
+        $value = mb_substr($line, $pos_from-1, $length);
         $this->storeValue($rule->to, $value);
         break;
 

--- a/extension/CRM/Banking/PluginImpl/Importer/Fixed.php
+++ b/extension/CRM/Banking/PluginImpl/Importer/Fixed.php
@@ -167,7 +167,13 @@ class CRM_Banking_PluginImpl_Importer_Fixed extends CRM_Banking_PluginModel_Impo
 
       // check encoding if necessary
       if (isset($config->encoding)) {
-        $line = mb_convert_encoding($line, mb_internal_encoding(), $config->encoding);
+        if (in_array($config->encoding, mb_list_encodings())) {
+          $line = mb_convert_encoding($line, mb_internal_encoding(), $config->encoding);
+        } else if (extension_loaded('iconv')) {
+          $line = iconv($config->encoding, mb_internal_encoding(), $line);
+        } else {
+          trigger_error("Unknown encoding {$config->encoding}, try enabling the iconv PHP extension", E_USER_ERROR);
+        }
       }
 
       $this->apply_rules('generic_rules', $line, $params);


### PR DESCRIPTION
This adds support for all encodings supported by iconv. Previously, encodings not supported by PHP's multibyte string library would cause errors.

This also fixes an issue with files containing multibyte strings when processed using the fixed width import plugin.