### PR TITLE
Linking a new payment for a membership in membership extension post processor

### DIFF
--- a/extension/CRM/Banking/PluginImpl/PostProcessor/MembershipExtension.php
+++ b/extension/CRM/Banking/PluginImpl/PostProcessor/MembershipExtension.php
@@ -262,7 +262,7 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipExtension extends CRM_Banki
     $contribution_id = (int) $contribution_id;
     $membership_id   = (int) $membership_id;
     if ($contribution_id && $membership_id)
-      $already_linked = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_membership_payment WHERE contribution_id = %1 OR membership_id = %2 LIMIT 1;", [
+      $already_linked = CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_membership_payment WHERE contribution_id = %1 AND membership_id = %2 LIMIT 1;", [
           1 => [$contribution_id, 'Integer'],
           2 => [$membership_id,   'Integer']]);
 


### PR DESCRIPTION
When you want to extend a membership with a newly created contribution from CiviBanking. You can use the post processor to link this payment to the membership and extend it. 

However if there are already payments linked to the membership the membership gets extended but the payment does **not** get linked to the membership. 

This PR fixes that.