### PR TITLE
Fix fatal error in MembershipPayment processor with PHP 7.1

### DIFF
--- a/extension/CRM/Banking/PluginImpl/PostProcessor/MembershipPayment.php
+++ b/extension/CRM/Banking/PluginImpl/PostProcessor/MembershipPayment.php
@@ -305,6 +305,9 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipPayment extends CRM_Banking
     }
 
     // add return clause
+    if (!is_array($config->contribution_fields_required)) {
+      $config->contribution_fields_required = [];
+    }
     $config->contribution_fields_required[] = 'id';
     $config->contribution_fields_required[] = 'contribution_recur_id';
     $config->contribution_fields_required[] = 'payment_instrument_id';


### PR DESCRIPTION
This fixes an issue where the empty index operator is applied to a string, which causes a fatal error with PHP 7.1.

Reference: https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.empty-string-index-operator