### PR TITLE
improve CsvImporter 'amount' to filter thousand separators

### DIFF
--- a/extension/CRM/Banking/PluginImpl/Importer/CSV.php
+++ b/extension/CRM/Banking/PluginImpl/Importer/CSV.php
@@ -392,6 +392,10 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
 
     } elseif ($this->startsWith($rule->type, 'amount')) {
       // AMOUNT will take care of currency issues, like "," instead of "."
+      $btx[$rule->to] = str_replace(",", ".", $value);
+
+    } elseif ($this->startsWith($rule->type, 'amountparse')) {
+      // AMOUNT will take care of currency issues, like "," instead of "."
       $value = preg_replace('/\.(?=[\d\.]*,\d{2}\b)/', '', $value); //remove thousand separator dots (e.g. in "10.000,00")
       $value = preg_replace('/,(?=[\d,]*\.\d{2}\b)/', '', $value); //remove thousand separator commas (e.g. in "10,000.00") 
       $btx[$rule->to] = str_replace(",", ".", $value);

--- a/extension/CRM/Banking/PluginImpl/Importer/CSV.php
+++ b/extension/CRM/Banking/PluginImpl/Importer/CSV.php
@@ -392,6 +392,8 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
 
     } elseif ($this->startsWith($rule->type, 'amount')) {
       // AMOUNT will take care of currency issues, like "," instead of "."
+      $value = preg_replace('/\.(?=[\d\.]*,\d{2}\b)/', '', $value); //remove thousand separator dots (e.g. in "10.000,00")
+      $value = preg_replace('/,(?=[\d,]*\.\d{2}\b)/', '', $value); //remove thousand separator commas (e.g. in "10,000.00") 
       $btx[$rule->to] = str_replace(",", ".", $value);
 
     } elseif ($this->startsWith($rule->type, 'regex:')) {


### PR DESCRIPTION
We were facing problems with some bank statement imports that included amounts with the German formatting including thousand separators like `10.000,00` which resulted in an imported amount of "10.00" instead of "10000.00".
As I failed to write a RegexAnalyser to fix the values I patched the Importer and propose this PR.