### PR TITLE
implemented probability setting for bank account matching

### DIFF
--- a/extension/CRM/Admin/Form/Setting/BankingSettings.php
+++ b/extension/CRM/Admin/Form/Setting/BankingSettings.php
@@ -105,6 +105,13 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
       'reference_validation',
       E::ts('Validate bank account references'),
       '');
+    // validate bank account references?
+    $this->addElement(
+      'text',
+      'reference_matching_probability',
+      E::ts('Probability of contact matching based on bank account'),
+      '');
+    $this->addRule('reference_matching_probability', E::ts('Not a valid number. A valid number is 1.0 or 0.9'), 'numeric');
 
     // validate bank account references?
     $this->addElement(
@@ -140,6 +147,10 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     $defaults['banking_log_file']         = CRM_Core_BAO_Setting::getItem('CiviBanking', 'banking_log_file');
     $defaults['reference_store_disabled'] = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_store_disabled');
     $defaults['reference_normalisation']  = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_normalisation');
+    $defaults['reference_matching_probability']     = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_matching_probability');
+    if ($defaults['reference_matching_probability'] === null) {
+      $defaults['reference_matching_probability'] = '1.0';
+    }
     $defaults['reference_validation']     = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_validation');
     $defaults['lenient_dedupe']           = CRM_Core_BAO_Setting::getItem('CiviBanking', 'lenient_dedupe');
 
@@ -176,6 +187,7 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     // process reference normalisation / validation
     CRM_Core_BAO_Setting::setItem(!empty($values['reference_store_disabled']),'CiviBanking', 'reference_store_disabled');
     CRM_Core_BAO_Setting::setItem(!empty($values['reference_normalisation']), 'CiviBanking', 'reference_normalisation');
+    CRM_Core_BAO_Setting::setItem($values['reference_matching_probability'], 'CiviBanking', 'reference_matching_probability');
     CRM_Core_BAO_Setting::setItem(!empty($values['reference_validation']),    'CiviBanking', 'reference_validation');
     CRM_Core_BAO_Setting::setItem(!empty($values['lenient_dedupe']),          'CiviBanking', 'lenient_dedupe');
 

--- a/extension/CRM/Banking/BAO/BankAccount.php
+++ b/extension/CRM/Banking/BAO/BankAccount.php
@@ -39,7 +39,7 @@ class CRM_Banking_BAO_BankAccount extends CRM_Banking_DAO_BankAccount {
     } else {
       $params['modified_date'] = date('YmdHis');
     }
-    
+
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'BankAccount', CRM_Utils_Array::value('id', $params), $params);
 
@@ -88,12 +88,17 @@ class CRM_Banking_BAO_BankAccount extends CRM_Banking_DAO_BankAccount {
    *          ordered by the reference types' order in the option group
    */
   public function getReferences() {
+    $bank_account_reference_matching_probability = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_matching_probability');
+    if ($bank_account_reference_matching_probability === null) {
+      $bank_account_reference_matching_probability = 1.0;
+    }
+
     $orderedReferences = array();
-    $sql = "SELECT 
-                civicrm_option_value.value               AS reference_type, 
-                civicrm_option_value.label               AS reference_type_label, 
-                civicrm_option_value.description         AS reference_type_description, 
-                civicrm_option_value.id                  AS reference_type_id, 
+    $sql = "SELECT
+                civicrm_option_value.value               AS reference_type,
+                civicrm_option_value.label               AS reference_type_label,
+                civicrm_option_value.description         AS reference_type_description,
+                civicrm_option_value.id                  AS reference_type_id,
                 civicrm_bank_account_reference.reference AS reference,
                 civicrm_bank_account_reference.id        AS reference_id,
                 civicrm_bank_account.contact_id          AS contact_id,
@@ -116,7 +121,8 @@ class CRM_Banking_BAO_BankAccount extends CRM_Banking_DAO_BankAccount {
                                      'contact_id'                 => $orderedReferenceQuery->contact_id,
                                      'contact_ok'                 => ((!empty($orderedReferenceQuery->contact_id))
                                                                      && empty($orderedReferenceQuery->is_deleted)
-                                                                     && empty($orderedReferenceQuery->is_deceased)) ? '1' : '0'
+                                                                     && empty($orderedReferenceQuery->is_deceased)) ? '1' : '0',
+                                    'probability'                 => $bank_account_reference_matching_probability,
           );
     }
     return $orderedReferences;

--- a/extension/CRM/Banking/Matcher/Context.php
+++ b/extension/CRM/Banking/Matcher/Context.php
@@ -28,9 +28,16 @@ class CRM_Banking_Matcher_Context {
   // will store cached data needed/produced by the helper functions
   private $_caches;
 
+  protected $bank_account_reference_matching_probability = null;
+
   public function __construct( CRM_Banking_BAO_BankTransaction $btx ) {
     $this->btx = $btx;
     $btx->context = $this;
+
+    $this->bank_account_reference_matching_probability = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_matching_probability');
+    if ($this->bank_account_reference_matching_probability === null) {
+      $this->bank_account_reference_matching_probability = 1.0;
+    }
   }
 
   /**
@@ -78,7 +85,7 @@ class CRM_Banking_Matcher_Context {
     // look up accounts
     $account_owners = $this->getAccountContacts();
     foreach ($account_owners as $account_owner) {
-      $contacts[$account_owner] = 1.0;
+      $contacts[$account_owner] = $this->bank_account_reference_matching_probability;
     }
 
     // check if multiple 1.0 probabilities are there...

--- a/extension/CRM/Banking/Page/Review.php
+++ b/extension/CRM/Banking/Page/Review.php
@@ -130,12 +130,15 @@ class CRM_Banking_Page_Review extends CRM_Core_Page {
 
         $this->assign('party_ba', $ba_bao);
         $this->assign('party_ba_data_parsed', json_decode($ba_bao->data_parsed, true));
-        $this->assign('party_ba_references', $ba_bao->getReferences());
-
-        // deprecated: contact can also be identified via other means, see below
-        if ($ba_bao->contact_id && empty($contact)) {
-          $contact = $this->getContactSafe($ba_bao->contact_id);
+        $party_ba_references = $ba_bao->getReferences();
+        foreach($party_ba_references as $_idx=>$_party_ba_reference) {
+          if ($_party_ba_reference['probability'] >= 1.0 && empty($contact)) {
+            $contact = $this->getContactSafe($_party_ba_reference['contact_id']);
+          }
+          $party_ba_references[$_idx]['color'] = $this->translateProbability($_party_ba_reference['probability'] * 100);
+          $party_ba_references[$_idx]['probability'] = sprintf('%d%%', ($_party_ba_reference['probability'] * 100));
         }
+        $this->assign('party_ba_references', $party_ba_references);
       } else {
         // there is no party bank account connected this (yet)
         foreach ($data_parsed as $key => $value) {
@@ -249,7 +252,7 @@ class CRM_Banking_Page_Review extends CRM_Core_Page {
         } elseif (isset($_REQUEST['s_list'])) {
           $this->assign('url_back', banking_helper_buildURL('civicrm/banking/statements', array()));
           $this->assign('back_to_statement_lines', false);
-        }  
+        }
       }
 
       if (isset($next_pid)) {

--- a/extension/CRM/Banking/Upgrader.php
+++ b/extension/CRM/Banking/Upgrader.php
@@ -38,25 +38,25 @@ class CRM_Banking_Upgrader extends CRM_Banking_Upgrader_Base {
 
     return TRUE;
   }
-  
+
   /**
-   * When upgrading the extension keep the new UI disabled. 
+   * When upgrading the extension keep the new UI disabled.
    * This way the new UI is only visible upon a new installation.
-   * 
+   *
    * Also update the order of the transaction statuses as we use the order to sort the statement lines screen.
-   * 
+   *
    * @return TRUE on success
    */
   public function upgrade_0611() {
     CRM_Core_BAO_Setting::setItem(false, 'org.project60.banking', 'new_ui');
-    
+
     // Update order of the option group banking_tx_status.
     $statusApi = civicrm_api3('OptionValue', 'get', array('option_group_id' => 'civicrm_banking.bank_tx_status', 'options' => array('limit' => 0)));
     $statuses = array();
     foreach($statusApi['values'] as $status) {
       $statuses[$status['name']] = $status;
     }
-    
+
     // Set ignore status the weight from processed
     CRM_Core_DAO::executeQuery("UPDATE civicrm_option_value SET weight = %1 WHERE id = %2", array(
       1=> array($statuses['processed']['weight'], 'Integer'),
@@ -175,6 +175,18 @@ class CRM_Banking_Upgrader extends CRM_Banking_Upgrader_Base {
   public function upgrade_0704() {
     // rebuild menu, in particular for the UI
     CRM_Core_Invoke::rebuildMenuAndCaches();
+    CRM_Core_BAO_Setting::setItem($values['reference_matching_probability'], 'CiviBanking', 'reference_matching_probability');
+    return true;
+  }
+
+  /**
+   * Upgrader for 0.8 release
+   *
+   * @return TRUE on success
+   */
+  public function upgrade_0800() {
+    // Set the bank account reference probability to 100%.
+    CRM_Core_BAO_Setting::setItem('1.0', 'CiviBanking', 'reference_matching_probability');
     return true;
   }
 }

--- a/extension/banking.php
+++ b/extension/banking.php
@@ -46,6 +46,9 @@ function banking_civicrm_install() {
   //add the required option groups
   banking_civicrm_install_options(_banking_options());
 
+  // Set the bank account reference probability to 100%.
+  CRM_Core_BAO_Setting::setItem('1.0', 'CiviBanking', 'reference_matching_probability');
+
   return _banking_civix_civicrm_install();
 }
 

--- a/extension/templates/CRM/Admin/Form/Setting/BankingSettings.tpl
+++ b/extension/templates/CRM/Admin/Form/Setting/BankingSettings.tpl
@@ -55,6 +55,14 @@
 </div>
 
 <div class="crm-section">
+  <div class="label">{$form.reference_matching_probability.label}</div>
+  <div class="content">{$form.reference_matching_probability.html}
+    <p class="description">{ts domain='org.project60.banking'}E.g. 1.0 or 0.9. A number of 1 means an exact match (it means the system is 100% sure) a number lower than 1.0 means the system is sure for that percentage.{/ts}</p>
+  </div>
+  <div class="clear"></div>
+</div>
+
+<div class="crm-section">
   <div class="label">{$form.reference_validation.label}</div>
   <div class="content">{$form.reference_validation.html}</div>
   <div class="clear"></div>

--- a/extension/templates/CRM/Banking/Page/ReviewDebtor.tpl
+++ b/extension/templates/CRM/Banking/Page/ReviewDebtor.tpl
@@ -13,8 +13,8 @@
                 {if $party_ba_references.0}
                     {assign var=ba_contact_id value=$party_ba_references.0.contact_id}
                     {if !$party_ba_references.0.contact_ok}<strike>{/if}
-                    <a title="{$party_ba_references.0.reference_type_label}">{$party_ba_references.0.reference}</a>
-                    <a href="{crmURL p="civicrm/contact/view" q="reset=1&cid=$ba_contact_id"}">[{$ba_contact_id}]</a>
+                    <a style="color: {$party_ba_references.0.color};" title="{$party_ba_references.0.reference_type_label}">{$party_ba_references.0.reference}</a>
+                    <a style="color: {$party_ba_references.0.color};" href="{crmURL p="civicrm/contact/view" q="reset=1&cid=$ba_contact_id"}">[{$party_ba_references.0.probability}, {$ba_contact_id}]</a>
                     {if !$party_ba_references.0.contact_ok}</strike>{/if}
                 {elseif $party_account_ref}
                     <span title="{$party_account_reftypename}" class="notfound">{$party_account_ref} ({$party_account_reftype2})</span>


### PR DESCRIPTION
**Current situation**

When a transaction is matched by bank account this contact gets a probability of 100%. Meaning that in some matchers the transaction is matched with 100% certainity to this contact. 
Sometimes this is not the desired situation. 

For example in an organization where membership are stored on the household the individual might pay for the membership and as soon as the bank account is stored at the person level all other 'magic' disappears for identifying the household and the payment is recorded at the individual with 100% certainty and therefor the matcher is executed automatically.

**Proposed solution**

A setting where we can set the percentage for probability for bank account matching. In the above use case I am then able to lower the certainty so that automatic execution of those matches is prevented. 

The setting is defaulted to 1.0 so when updating banking the current behavior is left as it is.

See below the screenshots of the setting screen and the matching screen

![Screenshot_20201126_114848](https://user-images.githubusercontent.com/4126292/100342160-e15a4700-2fdd-11eb-815d-c7df0c17bb0a.png)

![Screenshot_20201126_114910](https://user-images.githubusercontent.com/4126292/100342170-e3bca100-2fdd-11eb-9fd3-6949efbb2460.png)
