### PR TITLE
[#293] [PHP 7.2 compatibility] Avoid PHP warning

### DIFF
--- a/extension/CRM/Banking/Page/StatementLine.php
+++ b/extension/CRM/Banking/Page/StatementLine.php
@@ -56,7 +56,7 @@ class CRM_Banking_Page_StatementLine extends CRM_Core_Page {
       $line['amount'] = $lineDao->amount;
       $line['currency'] = $lineDao->currency;
       $line['data_parsed'] = json_decode($lineDao->data_parsed, true);
-      $line['suggestions'] = json_decode($lineDao->suggestions, true);
+      $line['suggestions'] = json_decode($lineDao->suggestions, true) ?: [];
       $line['suggestion_count'] = count($line['suggestions']);
       $line['status'] = $lineDao->status_label;
       $line['status_name'] = $lineDao->status_name;


### PR DESCRIPTION
Avoid PHP warning "count(): Parameter must be an array or an object that implements Countable" when listing bank statements without suggestions