### PR TITLE
Show whitespace sequences in UI if they're significant

### DIFF
--- a/extension/CRM/Banking/Form/StatementSearch.php
+++ b/extension/CRM/Banking/Form/StatementSearch.php
@@ -209,7 +209,7 @@ class CRM_Banking_Form_StatementSearch extends CRM_Core_Form
             '_BIC'            => E::ts('Your BIC (<code>_BIC</code>)'),
             '_party_IBAN'     => E::ts('Other\'s IBAN (<code>_party_IBAN</code>)'),
             '_party_BIC'      => E::ts('Other\'s BIC (<code>_party_BIC</code>)'),
-            'cancel_reason'   => E::ts('Other\'s IBAN (<code>cancel_reason</code>)'),
+            'cancel_reason'   => E::ts('Cancel Reason (<code>cancel_reason</code>)'),
             '__other__'       => E::ts('other'),
         ];
     }
@@ -429,7 +429,7 @@ class CRM_Banking_Form_StatementSearch extends CRM_Core_Form
             %2";
 
       $count_sql_query = "
-        SELECT COUNT(DISTINCT(tx.id)) 
+        SELECT COUNT(DISTINCT(tx.id))
         FROM
             civicrm_bank_tx AS tx
         LEFT JOIN
@@ -474,7 +474,7 @@ class CRM_Banking_Form_StatementSearch extends CRM_Core_Form
                                                         $transactionDao->our_account_references, $data_parsed, true),
                 'other_account' => self::renderAccounts($transactionDao->other_account_id, $transactionDao->other_account_data,
                                                         $transactionDao->other_account_references, $data_parsed, false),
-                'purpose'       => $purpose,
+                'purpose'       => '<span style="white-space: pre-wrap">' . $purpose . '</span>',
                 'review_link'   => E::ts('<a href="%1" class="crm-popup">[#%2]</a>', [1 => $review_link, 2 => $transactionDao->id]),
             ];
         }

--- a/extension/css/banking.css
+++ b/extension/css/banking.css
@@ -56,6 +56,9 @@
   width: 100%;
   margin: 0;
 }
+.significant-whitespace {
+  white-space: pre-wrap;
+}
 #btx-details {
   float: left;
   width: 100%;

--- a/extension/templates/CRM/Banking/Page/ReviewDetails.tpl
+++ b/extension/templates/CRM/Banking/Page/ReviewDetails.tpl
@@ -11,7 +11,7 @@
         <td>
             <table class="explorer">
                 {foreach from=$extra_data key=k item=v}
-                    <tr><td class="xk">{ts domain='org.project60.banking'}{$k}{/ts}</td><td class="btx-detail-entry">{$v}</td></tr>
+                    <tr><td class="xk">{ts domain='org.project60.banking'}{$k}{/ts}</td><td class="btx-detail-entry significant-whitespace">{$v}</td></tr>
                 {/foreach}
             </table>
         </td>

--- a/extension/templates/CRM/Banking/Page/ReviewPurpose.tpl
+++ b/extension/templates/CRM/Banking/Page/ReviewPurpose.tpl
@@ -4,7 +4,7 @@
             <div class="btxlabel">{ts domain='org.project60.banking'}Purpose{/ts}</div>
             <div class="btxvalue btxl">
                 {*{$payment_data_raw.move_msg}&nbsp;*}
-                {$payment_data_parsed.purpose}
+                <span class="significant-whitespace">{$payment_data_parsed.purpose}</span>
             </div>
         </td>
     </tr>


### PR DESCRIPTION
In some parts of the UI where values may be used for searches or as part of banking rules, whitespace sequences (i.e. two spaces) may be significant and would cause a rule/search not to match when these values are copied and pasted without the sequence.

HTML's default behaviour is to ignore whitespace sequences. This changes the whitespace handling to show things like two consecutive spaces so that values may be copied safely.

The change is applied to the purpose/detail view on the transaction review page, and the purpose column of statement search.