### PR TITLE
GP-5333 Fix empty name cause exception in rule match lookup

### DIFF
--- a/extension/CRM/Banking/RuleMatchIndicators.php
+++ b/extension/CRM/Banking/RuleMatchIndicators.php
@@ -49,6 +49,9 @@ class CRM_Banking_RuleMatchIndicators
     public function addContactMatchIndicator()
     {
         $contactName = $this->transaction->getDataParsed()['name'];
+        if (empty($contactName)) {
+          return;
+        }
 
         $sql =
         "SELECT


### PR DESCRIPTION
This fixes an issue where empty names in banking transaction causes the name-based rule match lookup to throw an exception.