### PR TITLE
Skip BOM in CSV importer, e.g. for Paypal

### DIFF
--- a/extension/CRM/Banking/PluginImpl/Importer/CSV.php
+++ b/extension/CRM/Banking/PluginImpl/Importer/CSV.php
@@ -137,6 +137,10 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
     $bytes_read = 0;
     $header = array();
 
+    if (fgets($file, 4) !== "\xef\xbb\xbf") { // Skip BOM if present
+        rewind($file); // Or rewind pointer to start of file
+    }
+
     $batch = $this->openTransactionBatch();
     while (($line = fgetcsv($file, 0, $config->delimiter)) !== FALSE) {
       // update stats


### PR DESCRIPTION
See https://github.com/Project60/org.project60.banking/issues/300
I have not added the BOM-Skipping in the sentinel test, perhaps someone wants to test for the BOM.