### PR TITLE
fix #346 | wrong parameter name for option group id

### DIFF
--- a/extension/CRM/Banking/BAO/PluginInstance.php
+++ b/extension/CRM/Banking/BAO/PluginInstance.php
@@ -48,7 +48,7 @@ class CRM_Banking_BAO_PluginInstance extends CRM_Banking_DAO_PluginInstance {
    */
   static function listInstances($type_name, $enabled_only=TRUE) {
     // find the correct plugin type
-    $import_plugin_type = civicrm_api3('OptionValue', 'getsingle', array(
+    $import_plugin_type = civicrm_api3('OptionValue', 'get', array(
         'name'     => $type_name,
         'option_group_id' => 'civicrm_banking.plugin_classes',
         'option.limit' => 0));

--- a/extension/CRM/Banking/BAO/PluginInstance.php
+++ b/extension/CRM/Banking/BAO/PluginInstance.php
@@ -47,14 +47,10 @@ class CRM_Banking_BAO_PluginInstance extends CRM_Banking_DAO_PluginInstance {
    * @return array CRM_Banking_BAO_PluginInstances
    */
   static function listInstances($type_name, $enabled_only=TRUE) {
-    // first, find the plugin type option group
-    $plugin_types = civicrm_api3('OptionGroup', 'get', array(
-        'name' => 'civicrm_banking.plugin_types'));
-
-    // then, find the correct plugin type
-    $import_plugin_type = civicrm_api3('OptionValue', 'get', array(
+    // find the correct plugin type
+    $import_plugin_type = civicrm_api3('OptionValue', 'getsingle', array(
         'name'     => $type_name,
-        'group_id' => $plugin_types['id']));
+        'option_group_id' => 'civicrm_banking.plugin_classes'));
 
     // then, get the list of plugins matching this criteria
     $params = array('plugin_type_id' => $import_plugin_type['id']);


### PR DESCRIPTION
fix #346

Thanks to @sebalis and @Detsieber for working this out with me! 💪

It looks like the entire call to `OptionGroup.get` for receiving the option group id is unnecessary, so we removed that.
https://github.com/Project60/org.project60.banking/blob/ea20fd3a5cd5df44f7acf0754039ee97c5aef569/extension/CRM/Banking/BAO/PluginInstance.php#L50-L52

We changed the `OptionValue.get` call to an `OptionValue.getsingle` call to make sure it can only return one value. Also we renamed the `group_id` parameter to `option_group_id` and passed the hardcoded string for the plugin classes.
```php
// find the correct plugin type
$import_plugin_type = civicrm_api3('OptionValue', 'getsingle', array(
    'name'     => $type_name,
    'option_group_id' => 'civicrm_banking.plugin_classes'));
```