### PR TITLE
Change statements filter method from GET to POST

### DIFF
--- a/extension/templates/CRM/Banking/Page/Statements.tpl
+++ b/extension/templates/CRM/Banking/Page/Statements.tpl
@@ -1,6 +1,6 @@
 {crmScope extensionKey='org.project60.banking'}
 
-<form action="" method="get">
+<form action="" method="post">
   <div class="crm-block crm-form-block">
     <h3>{ts domain='org.project60.banking'}Showing statements for{/ts}</h3>
     <table class="form-layout">


### PR DESCRIPTION
Fixes the fact that the form does not submit correctly otherwise.

Tested and working on CiviCRM 5.37.0.