### PR TITLE
Adds composer.json to the repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "civicrm/banking",
+    "type": "civicrm-ext",
+    "description": "Automatic and semi-automatic processing of bank statements and other payment files.",
+    "license": "GNU AGPL v3 or later",
+    "authors": [
+        {
+            "name": "Bj&#xF6;rn Endres",
+            "email": "endres@systopia.de"
+        }
+    ]
+  }


### PR DESCRIPTION
@bjendres This PR adds a `composer.json` file inside the repository.

On the remote project, one needs to do the following to include CiviBanking:

Extract from `composer.json` :`
```json
{
    "name": "xxx",
    "description": "xxx",
    "type": "civicrm-ext",
    "license": "xxxx",
    "require": {
        "civicrm/banking": "1.0.0" <-- tag goes here
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/ixiam/org.project60.banking.git"
        }
    ]
}
```
This PR has been tested on my local `composer` builder and it did work as expected.

You've probably noticed that the 2 libraries that you use (eval-math & the json viewer) where not being included in the `composer.json` file.   
This is because it got way too much complicated by trying to add them so since you are not having so frequent updates on those libraries, it's preferable if we keep them to be included as-is .. or at least for now, as a starting point.
