### PR TITLE
Fix translation class not found error

### DIFF
--- a/banking.php
+++ b/banking.php
@@ -18,7 +18,7 @@ require_once 'banking.civix.php';
 require_once 'banking_options.php';
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-
+use CRM_Banking_ExtensionUtil as E;
 /**
  * Implements hook_civicrm_container().
  *


### PR DESCRIPTION
**It throws error**
`Error: Class 'E' not found in banking_civicrm_tabset()`