### PR TITLE
AccountsTab: Avoid deprecated method call

### DIFF
--- a/CRM/Banking/Form/AccountsTab.php
+++ b/CRM/Banking/Form/AccountsTab.php
@@ -74,7 +74,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
     $this->assign('reference_validation',    (int) CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_validation'));
 
     // ACCOUNT REFRENCE ITEMS
-    $this->add('hidden', 'contact_id', $contact_id, true);
+    $this->add('hidden', 'contact_id', $contact_id);
     $this->add('hidden', 'reference_id');
 
     $reference_type = $this->add(
@@ -95,7 +95,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
         true
     );
 
-    
+
     // BANK ITEMS
     $this->add('hidden', 'ba_id');
 
@@ -164,10 +164,10 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
             } elseif ($normalise && $result['normalised'] ) {
                 $values['reference'] = $result['reference'];
                 $this->set('reference', $result['reference']);
-            }            
+            }
         }
     }
-    
+
     if (0 == count($this->_errors)) {
         return TRUE;
     } else {
@@ -182,7 +182,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
   function postProcess() {
     $values = $this->exportValues();
     $was_created = FALSE;
-    
+
     // save presets
     if (!empty($values['reference_type'])) {
         CRM_Core_BAO_Setting::setItem($values['reference_type'], 'CiviBanking', 'account.default_reference_id');
@@ -190,7 +190,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
     if (!empty($values['country'])) {
         CRM_Core_BAO_Setting::setItem($values['country'], 'CiviBanking', 'account.default_country');
     }
-    
+
     // create bank account
     $ba_id = $values['ba_id'];
     if (empty($ba_id)) {
@@ -226,7 +226,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
     if (!empty($values['reference_id'])) {
         $reference_update['id'] = $values['reference_id'];
     }
-    
+
     civicrm_api3('BankingAccountReference', 'create', $reference_update);
 
     if ($was_created) {
@@ -237,7 +237,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
 
     // return to accounts tab
     if (!empty($values['contact_id'])) {
-        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$values['contact_id']}&selectedChild=bank_accounts"));        
+        CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/contact/view', "reset=1&cid={$values['contact_id']}&selectedChild=bank_accounts"));
     }
     parent::postProcess();
   }


### PR DESCRIPTION
Passing `true` as `$attributes` in `add()` triggers a deprecated error and has no impact.