### PR TITLE
CiviCRM5.60+ and PHP8 compatibility

### DIFF
--- a/CRM/Banking/Helpers/OptionValue.php
+++ b/CRM/Banking/Helpers/OptionValue.php
@@ -18,9 +18,9 @@ use CRM_Banking_ExtensionUtil as E;
 
 /**
  * looks up an option group ID
- * 
+ *
  * the implementation is probably not optimal, but it'll do for the moment
- * 
+ *
  * @package org.project60.banking
  * @copyright GNU Affero General Public License
  * $Id$
@@ -30,7 +30,7 @@ function banking_helper_optiongroupid_by_name($group_name) {
     $result = civicrm_api3('OptionGroup', 'get', array('name' => $group_name));
 
     if (empty($result['id'])) {
-      CRM_Core_Error::debug_log_message("org.project60.banking: Couldn't find option group '{$group_name}'!");
+      Civi::log()->debug("org.project60.banking: Couldn't find option group '{$group_name}'!");
       return 0;
     } else {
       return $result['id'];
@@ -40,9 +40,9 @@ function banking_helper_optiongroupid_by_name($group_name) {
 
 /**
  * looks up an option value
- * 
+ *
  * the implementation is probably not optimal, but it'll do for the moment
- * 
+ *
  * @package org.project60.banking
  * @copyright GNU Affero General Public License
  * $Id$
@@ -54,7 +54,7 @@ function banking_helper_optionvalueid_by_name($group_id, $value_name) {
         'option_group_id' => $group_id));
 
   if (empty($result['id'])) {
-    CRM_Core_Error::debug_log_message("org.project60.banking: Couldn't find option value '{$value_name}'!");
+    Civi::log()->debug("org.project60.banking: Couldn't find option value '{$value_name}'!");
     return 0;
   } else {
     return $result['id'];
@@ -63,9 +63,9 @@ function banking_helper_optionvalueid_by_name($group_id, $value_name) {
 
 /**
  * looks up an option value
- * 
+ *
  * the implementation is probably not optimal, but it'll do for the moment
- * 
+ *
  * @package org.project60.banking
  * @copyright GNU Affero General Public License
  * $Id$
@@ -77,7 +77,7 @@ function banking_helper_optionvalue_by_name($group_id, $value_name) {
         'option_group_id' => $group_id));
 
     if (empty($result['id'])) {
-      CRM_Core_Error::debug_log_message("org.project60.banking: Couldn't find option value '{$value_name}'!");
+      Civi::log()->debug("org.project60.banking: Couldn't find option value '{$value_name}'!");
       return 0;
     } else {
       return $result['values'][$result['id']]['value'];
@@ -86,9 +86,9 @@ function banking_helper_optionvalue_by_name($group_id, $value_name) {
 
 /**
  * looks up an option value ID by group name and value name
- * 
+ *
  * the implementation is probably not optimal, but it'll do for the moment
- * 
+ *
  * @package org.project60.banking
  * @copyright GNU Affero General Public License
  * $Id$
@@ -105,9 +105,9 @@ function banking_helper_optionvalueid_by_groupname_and_name($group_name, $value_
 
 /**
  * looks up an option value by group name and value name
- * 
+ *
  * the implementation is probably not optimal, but it'll do for the moment
- * 
+ *
  * @package org.project60.banking
  * @copyright GNU Affero General Public License
  * $Id$
@@ -124,9 +124,9 @@ function banking_helper_optionvalue_by_groupname_and_name($group_name, $value_na
 
 /**
  * creates an id/name => object mapping for the given option group
- * 
+ *
  * the implementation is probably not optimal, but it'll do for the moment
- * 
+ *
  * @package org.project60.banking
  * @copyright GNU Affero General Public License
  * $Id$
@@ -161,6 +161,6 @@ function banking_helper_optiongroup_id_name_mapping($group_name) {
  */
 function banking_helper_tx_status_closed($tx_status_id) {
     $status = banking_helper_optiongroup_id_name_mapping('civicrm_banking.bank_tx_status');
-    return $status[$tx_status_id]['name']=='processed' 
+    return $status[$tx_status_id]['name']=='processed'
         || $status[$tx_status_id]['name']=='ignored';
 }

--- a/CRM/Banking/Matcher/Engine.php
+++ b/CRM/Banking/Matcher/Engine.php
@@ -382,9 +382,11 @@ class CRM_Banking_Matcher_Engine {
   /**
    * Bulk-run a set of <n> unprocessed items
    *
-   * @param $max_count       the maximal amount of bank transactions to process
+   * @param integer $max_count
+   *   the maximal amount of bank transactions to process
    *
-   * @return the actual amount of bank transactions prcoessed
+   * @return integer
+   *   actual amount of bank transactions prcoessed
    */
   public function bulkRun($max_count) {
     $unprocessed_ids = CRM_Banking_BAO_BankTransaction::findUnprocessedIDs($max_count);

--- a/CRM/Banking/Page/AccountDedupe.php
+++ b/CRM/Banking/Page/AccountDedupe.php
@@ -369,7 +369,7 @@ class CRM_Banking_Page_AccountDedupe extends CRM_Core_Page {
           if (empty($result['is_error'])) {
             $refs_fixed += 1;
           } else {
-            CRM_Core_Error::debug_log_message("org.project60.banking.dedupe: Error while deleting dupe reference: " .$result['error_message']);
+            Civi::log()->debug("org.project60.banking.dedupe: Error while deleting dupe reference: " .$result['error_message']);
             $errors_ecountered += 1;
           }
         }

--- a/CRM/Banking/PluginImpl/PostProcessor/MembershipExtension.php
+++ b/CRM/Banking/PluginImpl/PostProcessor/MembershipExtension.php
@@ -760,7 +760,7 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipExtension extends CRM_Banki
           self::$_current_status_ids[] = $status['id'];
         }
       } catch (Exception $ex) {
-        CRM_Core_Error::debug_log_message("Unexpected error: " . $ex->getMessage());
+        Civi::log()->debug("Unexpected error: " . $ex->getMessage());
       }
     }
 
@@ -782,7 +782,7 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipExtension extends CRM_Banki
             'sequential'   => 0
         ])['values'];
       } catch (Exception $ex) {
-        CRM_Core_Error::debug_log_message("Unexpected error: " . $ex->getMessage());
+        Civi::log()->debug("Unexpected error: " . $ex->getMessage());
       }
     }
 

--- a/CRM/Banking/PluginModel/Base.php
+++ b/CRM/Banking/PluginModel/Base.php
@@ -117,7 +117,7 @@ abstract class CRM_Banking_PluginModel_Base {
    *
    * TODO: data format? float [0..1]?
    */
-  function reportProgress($progress, $message=None, $level=self::REPORT_LEVEL_INFO) {
+  function reportProgress($progress, $message='', $level=self::REPORT_LEVEL_INFO) {
     if ($progress==self::REPORT_PROGRESS_NONE) {
       // this means, no new progress has been made, simple take the last one
       $last_entry = array_slice( $this->_progress_log, -1, 1, TRUE );
@@ -139,7 +139,7 @@ abstract class CRM_Banking_PluginModel_Base {
       $_progress_callback->reportProgress($progress, $message, $level);
     }
     // log internally
-    array_push($this->_progress_log, array(date('Y-m-d H:i:s'), $progress, $message, $level));
+    $this->_progress_log[] = [date('Y-m-d H:i:s'), $progress, $message, $level];
   }
 
   /**

--- a/CRM/Banking/Rules/Rule.php
+++ b/CRM/Banking/Rules/Rule.php
@@ -662,7 +662,7 @@ class CRM_Banking_Rules_Rule {
       $field_name = $prefix . $raw_field_name;
       if (isset($params[$field_name]) && (strlen($params[$field_name]) > $max_length)) {
         $params[$field_name] = substr($params[$field_name], 0, $max_length);
-        CRM_Core_Error::debug_log_message("Field '{$field_name}' was too long and had to be truncated.");
+        Civi::log()->debug("Field '{$field_name}' was too long and had to be truncated.");
       }
     }
   }

--- a/CRM/Banking/Upgrader/Base.php
+++ b/CRM/Banking/Upgrader/Base.php
@@ -274,7 +274,7 @@ class CRM_Banking_Upgrader_Base {
       $setting = new CRM_Core_BAO_Setting();
       $setting->name = $this->extensionName . ':version';
       $setting->delete();
-      CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
+      Civi::log()->debug("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
     }
   }
 

--- a/api/v3/BankingLookup.php
+++ b/api/v3/BankingLookup.php
@@ -343,7 +343,7 @@ function _civicrm_api3_banking_lookup_contactbyname_penalties(&$contactID2probab
       if ((int) $penalty->relation_type_id) {
         $relation_type_ids[] = (int) $penalty->relation_type_id;
       } else {
-        CRM_Core_Error::debug_log_message("org.project60.banking.lookup - invalid or no 'relation_type_id' given in penalty definition.");
+        Civi::log()->debug("org.project60.banking.lookup - invalid or no 'relation_type_id' given in penalty definition.");
       }
     } elseif ($penalty->type == 'individual_single_name') {
       if (!empty($contactID2probability)) {
@@ -393,7 +393,7 @@ function _civicrm_api3_banking_lookup_contactbyname_penalties(&$contactID2probab
         }
 
       } else {
-        CRM_Core_Error::debug_log_message("org.project60.banking.lookup - penalty type not implemented: '{$penalty->type}'. Ignored.");
+        Civi::log()->debug("org.project60.banking.lookup - penalty type not implemented: '{$penalty->type}'. Ignored.");
       }
     }
     $contactID2probability[$contact_id] = $probability;

--- a/api/v3/BankingRule/Updatesearchresults.php
+++ b/api/v3/BankingRule/Updatesearchresults.php
@@ -36,6 +36,7 @@ function civicrm_api3_banking_rule_Updatesearchresults($params) {
   $all_results_params['options']['limit'] = 0;
   $all_results_params['options']['offset'] = 0;
   $results = CRM_Banking_Rules_Rule::search($all_results_params);
+  $rules = (array) $results['rules'];
 
   // Update them.
   // Currently only is_enabled is the only update we allow, but this could be
@@ -44,7 +45,7 @@ function civicrm_api3_banking_rule_Updatesearchresults($params) {
     && in_array($params['update']['is_enabled'], [0, 1])) {
 
     $enabled = (int) $params['update']['is_enabled'];
-    foreach ($results['rules'] as $rule) {
+    foreach ($rules as $rule) {
       $rule->setIs_enabled($enabled);
       $rule->save();
     }
@@ -55,7 +56,7 @@ function civicrm_api3_banking_rule_Updatesearchresults($params) {
   $limit  = (empty($params['options']['limit']) ? 10 : (int)$params['options']['limit']);
 
   $return = [];
-  foreach ($results['rules'] as $i=>$rule) {
+  foreach ($rules as $i=>$rule) {
     if ($i >= $offset && $i < $offset+$limit) {
       $return[] = $rule->getRuleData();
     }

--- a/api/v3/BankingTransaction.php
+++ b/api/v3/BankingTransaction.php
@@ -249,12 +249,12 @@ function _civicrm_api3_banking_transaction_analyselist_spec(&$spec) {
  */
 function civicrm_api3_banking_transaction_analyseoldest($params) {
   // first: check time restrictions
-  $now = strtotime('now');
+  $now = (int) strtotime('now');
   if (!empty($params['time'])) {
     // try to parse time
     $times = explode('-', $params['time']);
-    $from = strtotime($times[0]);
-    $to = strtotime($times[1]);
+    $from = (int) strtotime($times[0]);
+    $to = (int) strtotime($times[1]);
     if (empty($from) || empty($to)) {
       return civicrm_api3_create_error("Something's wrong with your time parameter. Expected format is 'hh:mm-hh:mm'.");
     }
@@ -284,14 +284,14 @@ function civicrm_api3_banking_transaction_analyseoldest($params) {
   $processed_count = $engine->bulkRun($max_count);
 
   // finally, compile the result
-  $after_exec = strtotime('now');
+  $after_exec = (int) strtotime('now');
   $result = array(
     'max_count' =>        $max_count,
     'processed_count' =>  $processed_count,
     'time'            =>  ($after_exec - $now),
   );
   if ($processed_count > 0) {
-    $result['time_per_tx'] = ($after_exec - $now) / $processed_count;
+    $result['time_per_tx'] = (float) ($after_exec - $now) / (float) $processed_count;
   }
 
   return civicrm_api3_create_success($result);
@@ -300,8 +300,9 @@ function civicrm_api3_banking_transaction_analyseoldest($params) {
 
 /**
  * extracts the individual transaction IDs from the parameter set
- * @param  list    comma separated list of bank_tx ids to process
- * @param  s_list  comma separated list of bank_tx_batch ids to process
+ * @param array $params list of paramters:
+ *    list    comma separated list of bank_tx ids to process
+ *    s_list  comma separated list of bank_tx_batch ids to process
  *
  * @return array of IDs
  */

--- a/configuration_database/Legacy_Configurations/importer/fixed/CH-LSV-v11.json
+++ b/configuration_database/Legacy_Configurations/importer/fixed/CH-LSV-v11.json
@@ -1,7 +1,7 @@
 {
    "sentinel": "#^(202|205)#",
    "defaults": {
-      "tx.currency": "EUR",
+      "tx.currency": "EUR"
       },
 	"generic_rules": [
       {


### PR DESCRIPTION
Various smaller fixes and adjustments that should grant CiviBanking compatibility with CiviCRM5.60+ and PHP8