### PR TITLE
Fix for #397

### DIFF
--- a/CRM/Banking/Matcher/Context.php
+++ b/CRM/Banking/Matcher/Context.php
@@ -85,7 +85,9 @@ class CRM_Banking_Matcher_Context {
     // look up accounts
     $account_owners = $this->getAccountContacts();
     foreach ($account_owners as $account_owner) {
-      $contacts[$account_owner] = $this->bank_account_reference_matching_probability;
+      if (!isset($contacts[$account_owner])) {
+        $contacts[$account_owner] = $this->bank_account_reference_matching_probability;
+      }
     }
 
     // check if multiple 1.0 probabilities are there...


### PR DESCRIPTION
Keep probability of already found contacts and do not overwrite them … with the bank account reference matching probability

See #397 