### PR TITLE
fix storing of json_editor_mode

### DIFF
--- a/CRM/Admin/Form/Setting/BankingSettings.php
+++ b/CRM/Admin/Form/Setting/BankingSettings.php
@@ -208,7 +208,7 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     }
 
     // process menu entry
-    Civi::settings()->set('json_editor_mode', $new_menu_position);
+    Civi::settings()->set('json_editor_mode', $values['json_editor_mode']);
 
     // log levels
     Civi::settings()->set('banking_log_level', $values['banking_log_level']);


### PR DESCRIPTION
Hi,

due a mixup of variables, an incorrect value (`$new_menu_position`) is currently stored for the JSON editor mode if user edit the banking settings. This leads to an exception with a message about an invalid mode, the JSON editor fails to load. Could you merge this fix and release a new version? Thanks!