### PR TITLE
CiviCRM 5.69 Compatibility

### DIFF
--- a/banking.civix.php
+++ b/banking.civix.php
@@ -98,18 +98,7 @@ function _banking_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
-
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
   _banking_civix_mixin_polyfill();

--- a/info.xml
+++ b/info.xml
@@ -33,5 +33,6 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.1</mixin>
   </mixins>
 </extension>

--- a/mixin/smarty-v2@1.0.1.mixin.php
+++ b/mixin/smarty-v2@1.0.1.mixin.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Auto-register "templates/" folder.
+ *
+ * @mixinName smarty-v2
+ * @mixinVersion 1.0.1
+ * @since 5.59
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+  $dir = $mixInfo->getPath('templates');
+  if (!file_exists($dir)) {
+    return;
+  }
+
+  $register = function() use ($dir) {
+    // This implementation has a theoretical edge-case bug on older versions of CiviCRM where a template could
+    // be registered more than once.
+    CRM_Core_Smarty::singleton()->addTemplateDir($dir);
+  };
+
+  // Let's figure out what environment we're in -- so that we know the best way to call $register().
+
+  if (!empty($GLOBALS['_CIVIX_MIXIN_POLYFILL'])) {
+    // Polyfill Loader (v<=5.45): We're already in the middle of firing `hook_config`.
+    if ($mixInfo->isActive()) {
+      $register();
+    }
+    return;
+  }
+
+  if (CRM_Extension_System::singleton()->getManager()->extensionIsBeingInstalledOrEnabled($mixInfo->longName)) {
+    // New Install, Standard Loader: The extension has just been enabled, and we're now setting it up.
+    // System has already booted. New templates may be needed for upcoming installation steps.
+    $register();
+    return;
+  }
+
+  // Typical Pageview, Standard Loader: Defer the actual registration for a moment -- to ensure that Smarty is online.
+  \Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($mixInfo, $register) {
+    if ($mixInfo->isActive()) {
+      $register();
+    }
+  });
+
+};


### PR DESCRIPTION
This pull requests adds a mixin to CiviBanking so that the smarty templates also works on CiviCRM 5.69 (this is broken in CiviCRM 5.69)