### PR TITLE
Fix: links to transactions in contribution view not working

### DIFF
--- a/CRM/Banking/BAO/BankTransactionContribution.php
+++ b/CRM/Banking/BAO/BankTransactionContribution.php
@@ -89,9 +89,9 @@ class CRM_Banking_BAO_BankTransactionContribution extends CRM_Banking_DAO_BankTr
    */
   public static function injectLinkedTransactions($page)
   {
-    if (!empty($page->_id) && ($page instanceof CRM_Contribute_Page_Tab)) {
+    if (!empty($_GET["id"]) && ($page instanceof CRM_Contribute_Page_Tab)) {
       try {
-        $contribution_id = (int) $page->_id;
+        $contribution_id = (int) $_GET["id"];
         $link_title = E::ts("CiviBanking Transaction");
         $tx_ids = self::getLinkedTransactions($contribution_id);
         if (!empty($tx_ids)) {


### PR DESCRIPTION
After upgrading to CiviBanking version `0.8.1`, and even after another upgrade to `1.1.0`, the links to related transactions that used to appear in the contribution view have disappeared.

After some investigation I found out that the problem lies in accessing a protected property in the function that is supposed to inject the links into the contribution view.

I changed the protected property to the value in `$_GET`, which also works.

I wonder why this has not bothered anyone else until today.