### PR TITLE
Fix NavMenu Icon for Compatibility with CiviCRM Core 5.77/Font Awesome 6

### DIFF
--- a/banking.php
+++ b/banking.php
@@ -217,7 +217,7 @@ function banking_civicrm_navigationMenu(&$menu) {
   _banking_civix_insert_navigation_menu($menu, $anchor, array(
     'label'      => E::ts('CiviBanking'),
     'name'       => 'CiviBanking',
-    'icon'       => (version_compare(CRM_Utils_System::version(), '5.6', '>=')) ? 'fa fa-btc' : '',
+    'icon'       => (version_compare(CRM_Utils_System::version(), '5.6', '>=')) ? 'crm-i fa-btc' : '',
     'permission' => 'access CiviContribute',
     'operator'   => 'OR',
     'separator'  => $separator,


### PR DESCRIPTION
### General
I couldn't find any specific contribution guidelines for this project, so I did my best to address this issue. If I missed any steps or requirements, just let me know :)

This PR addresses issue Project60/org.project60.banking#434 with the NavMenu icon in the CiviBanking extension after upgrading to CiviCRM Core ^5.77. The recent upgrade introduced a major change in Font Awesome, shifting from version 4 to version 6, which deprecated several older class names, including fa fa-btc.

### Changes Made
Utilized the crm-i wrapper for Font Awesome, as recommended in the [CiviCRM developer documentation](https://lab.civicrm.org/documentation/docs/dev/-/blob/master/docs/framework/ui.md?ref_type=heads#icons) to maintain compatibility with future updates.
### Testing
Manually verified that the NavMenu icon is displayed correctly after applying these changes on our CiviCrm System (attached screenshot)
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/410db17b-1da6-48fc-b05d-75dd223a0f71">
