### PR TITLE
fix json_editor_mode assignment in bespoke settings page

### DIFF
--- a/CRM/Admin/Form/Setting/BankingSettings.php
+++ b/CRM/Admin/Form/Setting/BankingSettings.php
@@ -208,7 +208,7 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     }
 
     // process menu entry
-    Civi::settings()->set('json_editor_mode', $new_menu_position);
+    Civi::settings()->set('json_editor_mode', $values['json_editor_mode']);
 
     // log levels
     Civi::settings()->set('banking_log_level', $values['banking_log_level']);


### PR DESCRIPTION
Currently submitting the settings page wrongly sets the json_editor_mode to a value of menu setting, which then crashes the UI config editor.