### PR TITLE
Use configured separator for matching line_filter

### DIFF
--- a/CRM/Banking/PluginImpl/Importer/CSV.php
+++ b/CRM/Banking/PluginImpl/Importer/CSV.php
@@ -40,6 +40,8 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
     if (!isset($config->defaults))       $config->defaults = array();
     if (!isset($config->rules))          $config->rules = array();
     if (!isset($config->drop_columns))   $config->drop_columns = array();
+    if (!isset($config->line_filter_use_delimiter))
+      $config->line_filter_use_delimiter = FALSE;
   }
 
   /**
@@ -151,6 +153,18 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
       rewind($file); // Or rewind pointer to start of file
     }
 
+    if (!empty($config->line_filter_use_delimiter)) {
+      $separator = $config->delimiter;
+    }
+    else {
+      // Legacy: use comma to rejoin row.
+      // @see https://github.com/Project60/org.project60.banking/issues/443
+      $separator = ',';
+    }
+
+    // Count filtered out lines.
+    $filtered_out = 0;
+
     $batch = $this->openTransactionBatch();
     while (($line = fgetcsv($file, 0, $config->delimiter)) !== FALSE) {
       // update stats
@@ -163,9 +177,10 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
 
       // check if we want to skip line (by filter)
       if (!empty($config->line_filter)) {
-        $full_line = trim(implode(',', $line));
+        $full_line = trim(implode($separator, $line));
         if (!preg_match($config->line_filter, $full_line)) {
           $config->header += 1;  // bump line numbers if filtered out
+          $filtered_out++;
           continue;
         }
       }
@@ -244,6 +259,10 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
       $this->closeTransactionBatch(TRUE);
     } else {
       $this->closeTransactionBatch(FALSE);
+    }
+
+    if ($filtered_out > 0) {
+        $this->reportProgress(1.0, E::ts('Filtered out %1 lines', [1 => $filtered_out]));
     }
     $this->reportDone();
   }

--- a/docs/configuration/plugins/importers/csv.md
+++ b/docs/configuration/plugins/importers/csv.md
@@ -35,6 +35,7 @@ configuration.
     "payment_instrument_id": 7
   },
   "line_filter": "#(Bedankt voor jouw donatie aan Stichting Voorbeeld)|(\"Status\",Direction,Processed.*)#",
+  "line_filter_use_delimiter": true,
   "filter": [
     {
       "type": "string_positive",
@@ -77,6 +78,12 @@ configuration.
     correctly. This means that the ID should exists in your database and reflect
     the payment instrument you want to use for the incoming transactions, for
     example SMS payment.
+
+Note that 'line_filter' is matched against each single row.
+It must also match the header row.
+
+If you set option `line_filter_use_delimiter` to `true` the matching of the lines 
+use the given `delimiter` to separate the columns (if not `,` is used).
 
 ## Test configuration
 


### PR DESCRIPTION
Added new config option `line_filter_use_delimiter` to activate behavior described in #443.

Existing configs use the old separator ',' - so existing workflows remain unchanged.
One can switch to the new behavior by adding `line_filter_use_delimiter` to the config.

I also added a progress message to show the number of filtered out lines and a short description in `docs/configuration/plugins/importers/csv.md`.

Accidentally PR against branch master - should it be 1.2.x?