### PR TITLE
Regression fix after #445

### DIFF
--- a/CRM/Banking/PluginImpl/Importer/CSV.php
+++ b/CRM/Banking/PluginImpl/Importer/CSV.php
@@ -33,8 +33,8 @@ class CRM_Banking_PluginImpl_Importer_CSV extends CRM_Banking_PluginModel_Import
     // read config, set defaults
     $config = $this->_plugin_config;
     if (!isset($config->delimiter))      $config->delimiter = ',';
-    if (!isset($config->enclosure))      $config->enclosure = '\\';
-    if (!isset($config->escape))         $config->escape = '"';
+    if (!isset($config->enclosure))      $config->enclosure = '"';
+    if (!isset($config->escape))         $config->escape = '\\';
     if (!isset($config->header))         $config->header = 1;
     if (!isset($config->warnings))       $config->warnings = true;
     if (!isset($config->skip))           $config->skip = 0;


### PR DESCRIPTION
The fix in #445 sets a default enclosure and escape but it turns out those have been swapped around.

This PR fixes that. 