### PR TITLE
Fixed #460 when contacts are found by their name and as account owner

### DIFF
--- a/CRM/Banking/Matcher/Context.php
+++ b/CRM/Banking/Matcher/Context.php
@@ -85,7 +85,7 @@ class CRM_Banking_Matcher_Context {
     // look up accounts
     $account_owners = $this->getAccountContacts();
     foreach ($account_owners as $account_owner) {
-      if (!isset($contacts[$account_owner])) {
+      if (!isset($contacts[$account_owner]) || $this->bank_account_reference_matching_probability > $contacts[$account_owner]) {
         $contacts[$account_owner] = $this->bank_account_reference_matching_probability;
       }
     }


### PR DESCRIPTION
In #460 we encountered a problem which was caused by the following:

In version 1.3 the `BankingLookup.contactbyname` api is refactored to use the core API4 `Contact.autocomplate` instead of the old v3 `contact.getquick`. At our environment (civicrm version 5.76) we did not have that old api. So the `BankingLookup.contactbyname` returned an error and no suggestions at all. The fix in banking 1.3 fixed this and thus returned a list of contacts.

This list contacts was found by the name and the probability was 99%. Which is good. However if a contact is also found as an account own the probability is not upgraded to 100%.

This PR fixes that,