### PR TITLE
quickfix for dark mode compatibility

### DIFF
--- a/css/banking.css
+++ b/css/banking.css
@@ -14,6 +14,7 @@
 }
 #btx {
   background-color: #F4F4ED;
+  color: #000;
 }
 #btx div {
 }
@@ -22,10 +23,12 @@
   margin: 0;
   border: none;
   background-color: #f7f7f7;
+  color: #000;
 }
 #btx h4 {
   width: auto;
   background-color: #CCC;
+  color: #000;
   margin: 0px;
   padding: 2px 8px;
   color: #000;
@@ -70,6 +73,7 @@ td.btx-detail-entry {
 }
 .btxvalue {
   background-color: #F4F4ED;
+  color: #000;
   border-bottom: 1px solid white;
 }
 .btxc {
@@ -93,6 +97,7 @@ td.btx-detail-entry {
 }
 .btxlabel {
   background-color: #FAFAFA;
+  color: #000;
   float: left;
   width: 46px;
   font-size: 9px;
@@ -191,6 +196,7 @@ table.explorer td.xk {
 }
 table.explorer td {
   background-color: #F4F4ED;
+  color: #000;
   border-bottom: 1px solid white;
   padding: 1px 4px !important;
 }


### PR DESCRIPTION
This is a quickfix for compatibility with Riverlea darkmode. It should not impact other settings.

Before
-------
Where the extension fixes a light background colour for various elements. But in a darkmode theme the text is also light - and so unreadable

![image](https://github.com/user-attachments/assets/bb25e1f7-8e00-4595-bf48-b6407e053190)



After
-------
Where the extension fixes a light background colour for various elements, it also fixes dark text

![image](https://github.com/user-attachments/assets/9b63bbd2-d0f4-4d90-81ab-5cc8f9c4b392)



Comments
-------
In long term it might be nice to use declarations like:
```
background-color: var(--crm-c-background, #F4F4ED);
color: var(--crm-c-text, #000);
```
That would respect the theme colour scheme, but fallback to the extension one if Riverlea not active. 

It might have some tricky cases where a semantic colour is used -- e.g. setting amounts to red.