### PR TITLE
Fix transaction links in contribution view

### DIFF
--- a/js/contribution_transaction_snippet.js
+++ b/js/contribution_transaction_snippet.js
@@ -15,12 +15,12 @@
 
 cj(document).ready(function() {
   // inject stuff
-  // todo: find better selector for the row in the contribution view we want to be injected after
   let previous_row = cj("div.crm-contribution-view-form-block")
       .find("table.crm-info-panel")
       .first()
-      .find("tr")
-      .get(8);
+      .children("tbody")
+      .children("tr")
+      .last();
   cj(previous_row)
       .after(`
         <tr>


### PR DESCRIPTION
The current implementation of the transaction link injection, which is hard-coded and adds the transaction link after the 8th line in the table, not only does not work very well when we have nested tables, but also fails completely in RiverLea-based themes because the first table does not have 8 lines.

I made the selector more robust by using the `.children()` method instead of the `.find()` method, which returns elements from all levels, which we want to avoid because of the nested tables.

I also decided to always add the row as the last row in the first table. This also keeps it more consistent when the number of rows varies due to notes, etc.

Works well in RiverLea-based themes:
<img width="1847" height="605" alt="Bildschirmfoto vom 2025-08-13 17-27-40" src="https://github.com/user-attachments/assets/e5eb1e93-8ca7-40f0-9c9f-a3260478145c" />

As well as in the standard theme:
<img width="1263" height="684" alt="Bildschirmfoto vom 2025-08-13 17-14-13" src="https://github.com/user-attachments/assets/89a2cfe9-8f9b-4903-a810-e9046d757dcc" />

And in others, like "The Island". And we do not mess with nested tables any more:
<img width="1259" height="873" alt="Bildschirmfoto vom 2025-08-13 17-01-12" src="https://github.com/user-attachments/assets/130db69d-73f2-4e93-abf3-2f56cbaab101" />

Fixes the issue of missing transaction links in RiverLea-based themes and #442.