### PR TITLE
Re-enable dropped smarty5 modifier 'range'

### DIFF
--- a/CRM/Banking/Form/StatementSearch.php
+++ b/CRM/Banking/Form/StatementSearch.php
@@ -42,7 +42,7 @@ class CRM_Banking_Form_StatementSearch extends CRM_Core_Form
 
         $this->buildSearchElements();
 
-        CRM_Core_Smarty::singleton()->registerPlugin("modifier", "range", "range");
+        CRM_Core_Smarty::singleton()->registerPlugin('modifier', 'range', 'range');
 
         $this->addButtons(
             [


### PR DESCRIPTION
systopia-reference: 29664

The ``@range`` modifier was dropped from the default modifiers with smarty5.
This PR will add the the modifier again where needed.