### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/CRM/Banking/Helpers/Smarty.php
+++ b/CRM/Banking/Helpers/Smarty.php
@@ -82,7 +82,7 @@ class CRM_Banking_Helpers_Smarty {
    * @see popScope
    */
   public function pushScope($vars) {
-    $oldVars = $this->smarty->get_template_vars();
+    $oldVars = $this->smarty->getTemplateVars();
     $backupFrame = array();
     foreach ($vars as $key => $value) {
       $backupFrame[$key] = isset($oldVars[$key]) ? $oldVars[$key] : NULL;

--- a/CRM/Banking/Page/Review.php
+++ b/CRM/Banking/Page/Review.php
@@ -326,7 +326,7 @@ class CRM_Banking_Page_Review extends CRM_Core_Page {
         $vars = $this->getTemplateVars();
       }
       else {
-        $vars = $this->get_template_vars();
+        $vars = $this->getTemplateVars();
       }
 
       $template = CRM_Core_Smarty::singleton();


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.