### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/project60/org.project60.banking/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.4.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.60</ver>
+    <ver>5.65</ver>
   </compatibility>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/templates/CRM/Banking/Form/AccountsTab.tpl
+++ b/templates/CRM/Banking/Form/AccountsTab.tpl
@@ -42,10 +42,10 @@
             <span title="{$reference.reference_type_label}">{$reference.reference}&nbsp;({$reference.reference_type})</span>
             {/if}
             {if $account.references|@count gt 1}
-            <a onClick="banking_deletereference({$account.id}, {$reference.id});" class="action-item action-item-first" title="{ts domain='org.project60.banking'}delete{/ts}">{ts domain='org.project60.banking'}[-]{/ts}</a>
+            <a onClick="banking_deletereference({$account.id}, {$reference.id});" class="action-item action-item-first" title="{ts escape='htmlattribute' domain='org.project60.banking'}delete{/ts}">{ts domain='org.project60.banking'}[-]{/ts}</a>
             {/if}
             {if $smarty.foreach.account_reference.last}
-            <a onClick="banking_addreference({$account.id});" class="action-item action-item-first" title="{ts domain='org.project60.banking'}add{/ts}">{ts domain='org.project60.banking'}[+]{/ts}</a>
+            <a onClick="banking_addreference({$account.id});" class="action-item action-item-first" title="{ts escape='htmlattribute' domain='org.project60.banking'}add{/ts}">{ts domain='org.project60.banking'}[+]{/ts}</a>
             {/if}
           </td></tr>
           {/foreach}
@@ -70,10 +70,10 @@
         </table>
       </td>
       <td style="vertical-align: middle;">
-        <a title="{ts domain='org.project60.banking'}Delete{/ts}" class="delete button" onClick="banking_deleteaccount({$account.id});">
+        <a title="{ts escape='htmlattribute' domain='org.project60.banking'}Delete{/ts}" class="delete button" onClick="banking_deleteaccount({$account.id});">
           <span><div class="icon delete-icon ui-icon-trash"></div>{ts domain='org.project60.banking'}Delete{/ts}</span>
         </a>
-        <a title="{ts domain='org.project60.banking'}Edit{/ts}" class="edit button" onClick="banking_editaccount({$account.id});">
+        <a title="{ts escape='htmlattribute' domain='org.project60.banking'}Edit{/ts}" class="edit button" onClick="banking_editaccount({$account.id});">
           <span><div class="icon edit-icon ui-icon-pencil"></div>{ts domain='org.project60.banking'}Edit{/ts}</span>
         </a>
       </td>
@@ -86,7 +86,7 @@
 <h3>{ts domain='org.project60.banking'}This contact has no known accounts associated with him/her.{/ts}</h3>
 {/if}
 
-<a id="banking_account_addbtn" title="{ts domain='org.project60.banking'}Add{/ts}" class="add button" onClick="banking_addaccount();">
+<a id="banking_account_addbtn" title="{ts escape='htmlattribute' domain='org.project60.banking'}Add{/ts}" class="add button" onClick="banking_addaccount();">
   <span><div class="icon add-icon ui-icon-add ui-icon-circle-plus"></div>{ts domain='org.project60.banking'}Add{/ts}</span>
 </a>
 
@@ -238,18 +238,18 @@ function banking_deletereference(ba_id, ref_id) {
     CRM.api('BankingAccountReference', 'delete', {'q': 'civicrm/ajax/rest', 'sequential': 1, 'id': ref_id},
     {success: function(data) {
         if (data['is_error'] == 0) {
-          CRM.alert("{/literal}{ts domain='org.project60.banking'}The bank account reference has been deleted{/ts}", "{ts domain='org.project60.banking'}Success{/ts}{literal}", "success");
+          CRM.alert("{/literal}{ts domain='org.project60.banking'}The bank account reference has been deleted{/ts}", "{ts escape='htmlattribute' domain='org.project60.banking'}Success{/ts}{literal}", "success");
           var contentId = cj('#tab_bank_accounts').attr('aria-controls');
           cj('#' + contentId).load(CRM.url('civicrm/banking/accounts_tab', {'reset': 1, 'snippet': 1, 'force': 1, 'cid':{/literal}{$contact_id}{literal}}));
         }else{
-          CRM.alert("{/literal}" + data['error_message'], "{ts domain='org.project60.banking'}Error{/ts}{literal}", "error");
+          CRM.alert("{/literal}" + data['error_message'], "{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}", "error");
         }
       }
     }
   );
   },
   {
-    message: {/literal}"{ts domain='org.project60.banking'}Are you sure you want to delete this bank account reference?{/ts}"{literal}
+    message: {/literal}"{ts escape='htmlattribute' domain='org.project60.banking'}Are you sure you want to delete this bank account reference?{/ts}"{literal}
   });
 }
 

--- a/templates/CRM/Banking/Page/Dashboard.tpl
+++ b/templates/CRM/Banking/Page/Dashboard.tpl
@@ -53,7 +53,7 @@ td.week_incomplete {
 	{if not $sum}{assign var=sum value=0}{/if}
 
 	{if $sum == 0}
-	<td class="week_none" title="{ts domain='org.project60.banking'}There are no records for this time span.{/ts}"><i>{ts domain='org.project60.banking'}no records{/ts}</i></td>
+	<td class="week_none" title="{ts escape='htmlattribute' domain='org.project60.banking'}There are no records for this time span.{/ts}"><i>{ts domain='org.project60.banking'}no records{/ts}</i></td>
 	{elseif $sum == $done}
 	<td class="week_complete" title="{$done} / {$sum}">100&nbsp;%</td>
 	{else}
@@ -67,7 +67,7 @@ td.week_incomplete {
 	{if not $sum}{assign var=sum value=0}{/if}
 
 	{if $sum == 0}
-	<td class="week_none" title="{ts domain='org.project60.banking'}There are no records for this time span.{/ts}"><i>{ts domain='org.project60.banking'}no records{/ts}</i></td>
+	<td class="week_none" title="{ts escape='htmlattribute' domain='org.project60.banking'}There are no records for this time span.{/ts}"><i>{ts domain='org.project60.banking'}no records{/ts}</i></td>
 	{elseif $sum == $done}
 	<td class="week_complete" title="{$done} / {$sum}">100&nbsp;%</td>
 	{else}

--- a/templates/CRM/Banking/Page/Manager.tpl
+++ b/templates/CRM/Banking/Page/Manager.tpl
@@ -85,14 +85,14 @@ tr.banking-plugin-disabled {
 					<ul class="panel">
 						<li>
 							{if $importer.enabled}
-								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
 							{else}
-								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
 							{/if}
-							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
 						</li>
 					</ul>
 				</span>
@@ -138,14 +138,14 @@ tr.banking-plugin-disabled {
 					<ul class="panel">
 						<li>
 							{if $matcher.enabled}
-								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
 							{else}
-								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
 							{/if}
-							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
 						</li>
 					</ul>
 				</span>
@@ -191,14 +191,14 @@ tr.banking-plugin-disabled {
 					<ul class="panel">
 						<li>
 							{if $postprocessor.enabled}
-								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
 							{else}
-								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
 							{/if}
-							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
 						</li>
 					</ul>
 				</span>
@@ -244,14 +244,14 @@ tr.banking-plugin-disabled {
 					<ul class="panel">
 						<li>
 							{if $exporter.enabled}
-								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="disable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Disable{/ts}">{ts domain='org.project60.banking'}Disable{/ts}</a>
 							{else}
-								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
+								<a href="{crmURL p='civicrm/banking/manager' q="enable=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Enable{/ts}">{ts domain='org.project60.banking'}Enable{/ts}</a>
 							{/if}
-							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
-							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/configure' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Configure{/ts}">{ts domain='org.project60.banking'}Configure{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="export=$plugin_id"}" class="action-item crm-hover-button export-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Export Configuration{/ts}">{ts domain='org.project60.banking'}Export Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/pluginupload' q="reset=1&pid=$plugin_id"}" class="action-item crm-hover-button update-config small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Update Configuration{/ts}">{ts domain='org.project60.banking'}Update Configuration{/ts}</a>
+							<a href="{crmURL p='civicrm/banking/manager' q="delete=$plugin_id"}" class="action-item crm-hover-button delete-contact small-popup" title="{ts escape='htmlattribute' domain='org.project60.banking'}Delete{/ts}">{ts domain='org.project60.banking'}Delete{/ts}</a>
 						</li>
 					</ul>
 				</span>

--- a/templates/CRM/Banking/Page/Payments.tpl
+++ b/templates/CRM/Banking/Page/Payments.tpl
@@ -240,7 +240,7 @@ function callWithSelected(url, forced) {
     location.href = url.replace("__selected__", selected);
   } else {
     {/literal}
-    var message = "{ts domain='org.project60.banking'}Please select one or more items{/ts}";
+    var message = "{ts escape='htmlattribute' domain='org.project60.banking'}Please select one or more items{/ts}";
     {literal}
     window.alert(message);
   }
@@ -301,7 +301,7 @@ function processSelected() {
             {literal}
             message = message.replace('_1', data.values.payment_count-data.values.processed_count);
             message = message.replace('_2', data.values.payment_count);
-            cj('<div title="{/literal}{ts domain='org.project60.banking'}Process timed out{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + message + '</div>').dialog({
+            cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Process timed out{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + message + '</div>').dialog({
               modal: true,
               buttons: {
                 Ok: function() { location.reload(); }
@@ -309,7 +309,7 @@ function processSelected() {
             });
           }
         } else {
-          cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+          cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
             modal: true,
             buttons: {
               Ok: function() { location.reload(); }
@@ -346,14 +346,14 @@ function deleteSelected() {
           if (!data['is_error']) {
             // perfectly normal result, notify user
             {/literal}
-            var message = "{ts domain='org.project60.banking'}_1 payments in _2 statements have been deleted.{/ts}";
+            var message = "{ts escape='htmlattribute' domain='org.project60.banking'}_1 payments in _2 statements have been deleted.{/ts}";
             {literal}
             message = message.replace('_1', data.values.tx_count);
             message = message.replace('_2', data.values.tx_batch_count);
             CRM.alert(message, "info");
             window.setTimeout("location.reload()", 1500);
           } else {
-            cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+            cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
               modal: true,
               buttons: {
                 Ok: function() { location.reload(); }

--- a/templates/CRM/Banking/Page/Review.tpl
+++ b/templates/CRM/Banking/Page/Review.tpl
@@ -23,44 +23,44 @@
   <br/>
 
   <div align="right" class="clearfix" style="width: 100%;">
-    <a href="{$url_skip_back}" class="button {if not $url_skip_back}disabled{/if}  ui-icon-seek-prev"><span title="{ts domain='org.project60.banking'}Back{/ts}"><div class="icon previous-icon ui-icon-seek-prev disabled"></div>{ts domain='org.project60.banking'}Back{/ts}</span></a>
+    <a href="{$url_skip_back}" class="button {if not $url_skip_back}disabled{/if}  ui-icon-seek-prev"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Back{/ts}"><div class="icon previous-icon ui-icon-seek-prev disabled"></div>{ts domain='org.project60.banking'}Back{/ts}</span></a>
 
     {if $btxstatus.label != 'Processed' AND $btxstatus.label != 'Ignored'}
-      <a id="analyseButton" onClick="analysePayment()" class="button"><span title="{ts domain='org.project60.banking'}Analyse (again){/ts}"><div class="icon preview-icon ui-icon-refresh"></div>{ts domain='org.project60.banking'}Analyse (again){/ts}</span></a>
+      <a id="analyseButton" onClick="analysePayment()" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Analyse (again){/ts}"><div class="icon preview-icon ui-icon-refresh"></div>{ts domain='org.project60.banking'}Analyse (again){/ts}</span></a>
       {if isset($url_skip_forward)}
-        <a href="#" onClick="execute_selected()" class="button"><span title="{ts domain='org.project60.banking'}Confirm and Continue{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Continue{/ts}</span></a>
-        <a href="{$url_skip_forward}" class="button"><span title="{ts domain='org.project60.banking'}Skip{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip{/ts}</span></a>
+        <a href="#" onClick="execute_selected()" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Confirm and Continue{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Continue{/ts}</span></a>
+        <a href="{$url_skip_forward}" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Skip{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip{/ts}</span></a>
         {if $url_skip_processed}
-        <a href="{$url_skip_processed}" class="button"><span title="{ts domain='org.project60.banking'}Skip Processed{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip Processed{/ts}</span></a>
+        <a href="{$url_skip_processed}" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Skip Processed{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip Processed{/ts}</span></a>
         {/if}
       {else}
-        <a href="#" onClick="execute_selected()" class="button"><span title="{ts domain='org.project60.banking'}Confirm and Exit{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Exit{/ts}</span></a>
-        <a href="{$url_back}" class="button"><span title="{ts domain='org.project60.banking'}Skip and Exit{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip and Exit{/ts}</span></a>
+        <a href="#" onClick="execute_selected()" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Confirm and Exit{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Exit{/ts}</span></a>
+        <a href="{$url_back}" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Skip and Exit{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip and Exit{/ts}</span></a>
       {/if}
     {else}
-      <a id="analyseButton" onClick="analysePayment()" class="button disabled"><span title="{ts domain='org.project60.banking'}Analyse (again){/ts}"><div class="icon preview-icon ui-icon-refresh"></div>{ts domain='org.project60.banking'}Analyse (again){/ts}</span></a>
+      <a id="analyseButton" onClick="analysePayment()" class="button disabled"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Analyse (again){/ts}"><div class="icon preview-icon ui-icon-refresh"></div>{ts domain='org.project60.banking'}Analyse (again){/ts}</span></a>
       {if isset($url_skip_forward)}
-        <a href="" class="button disabled"><span title="{ts domain='org.project60.banking'}Confirm and Continue{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Continue{/ts}</span></a>
-        <a href="{$url_skip_forward}" class="button"><span title="{ts domain='org.project60.banking'}Skip{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip{/ts}</span></a>
+        <a href="" class="button disabled"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Confirm and Continue{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Continue{/ts}</span></a>
+        <a href="{$url_skip_forward}" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Skip{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip{/ts}</span></a>
         {if $url_skip_processed}
-        <a href="{$url_skip_processed}" class="button"><span title="{ts domain='org.project60.banking'}Skip Processed{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip Processed{/ts}</span></a>
+        <a href="{$url_skip_processed}" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Skip Processed{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip Processed{/ts}</span></a>
         {/if}
       {else}
-        <a href="" class="button disabled"><span title="{ts domain='org.project60.banking'}Confirm and Exit{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Exit{/ts}</span></a>
-        <a href="{$url_back}" class="button"><span title="{ts domain='org.project60.banking'}Skip and Exit{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip and Exit{/ts}</span></a>
+        <a href="" class="button disabled"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Confirm and Exit{/ts}"><div class="icon next-icon ui-icon-check"></div>{ts domain='org.project60.banking'}Confirm and Exit{/ts}</span></a>
+        <a href="{$url_back}" class="button"><span title="{ts escape='htmlattribute' domain='org.project60.banking'}Skip and Exit{/ts}"><div class="icon next-icon ui-icon-seek-next"></div>{ts domain='org.project60.banking'}Skip and Exit{/ts}</span></a>
       {/if}
     {/if}
     {if $new_ui_enabled && $back_to_statement_lines}
       <a href="{$url_back}" class="button" style="float:right;">
-        <span title="{ts domain='org.project60.banking'}Back{/ts}"><div class="icon back-icon ui-icon-arrowreturnthick-1-w"></div>{ts domain='org.project60.banking'}Back to statement lines{/ts}</span>
+        <span title="{ts escape='htmlattribute' domain='org.project60.banking'}Back{/ts}"><div class="icon back-icon ui-icon-arrowreturnthick-1-w"></div>{ts domain='org.project60.banking'}Back to statement lines{/ts}</span>
       </a>
     {elseif $new_ui_enabled && !$back_to_statement_lines}
       <a href="{$url_back}" class="button" style="float:right;">
-        <span title="{ts domain='org.project60.banking'}Back{/ts}"><div class="icon back-icon ui-icon-arrowreturnthick-1-w"></div>{ts domain='org.project60.banking'}Back to statements{/ts}</span>
+        <span title="{ts escape='htmlattribute' domain='org.project60.banking'}Back{/ts}"><div class="icon back-icon ui-icon-arrowreturnthick-1-w"></div>{ts domain='org.project60.banking'}Back to statements{/ts}</span>
       </a>
     {else}
       <a href="{$url_back}" class="button" style="float:right;">
-        <span title="{ts domain='org.project60.banking'}Back{/ts}"><div class="icon back-icon ui-icon-arrowreturnthick-1-w"></div>{ts domain='org.project60.banking'}Back to transaction list{/ts}</span>
+        <span title="{ts escape='htmlattribute' domain='org.project60.banking'}Back{/ts}"><div class="icon back-icon ui-icon-arrowreturnthick-1-w"></div>{ts domain='org.project60.banking'}Back to transaction list{/ts}</span>
       </a>
     {/if}
   </div>
@@ -174,7 +174,7 @@ function analysePayment() {
             window.location = newURL;
           }
         } else {
-          cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+          cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
             modal: true,
             buttons: {
               Ok: function() {

--- a/templates/CRM/Banking/Page/StatementLine.tpl
+++ b/templates/CRM/Banking/Page/StatementLine.tpl
@@ -18,7 +18,7 @@
     </table>
     
     <div class="crm-submit-buttons">
-    <input type="submit" class="crm-form-submit" value="{ts domain='org.project60.banking'}Filter{/ts}">
+    <input type="submit" class="crm-form-submit" value="{ts escape='htmlattribute' domain='org.project60.banking'}Filter{/ts}">
     </div>
   </div>
 </form>
@@ -65,7 +65,7 @@
         {/if}
       </td>
       <td><span>
-        <a class="action-item crm-hover-button" href="{crmURL p="civicrm/banking/review" q="list=`$list`&id=`$line.id`"}" title="{ts domain='org.project60.banking'}Walk through the payments and will show the suggestions and will give you the possibility to manually process the suggestions{/ts}">{ts domain='org.project60.banking'}Review transaction{/ts}</a>
+        <a class="action-item crm-hover-button" href="{crmURL p="civicrm/banking/review" q="list=`$list`&id=`$line.id`"}" title="{ts escape='htmlattribute' domain='org.project60.banking'}Walk through the payments and will show the suggestions and will give you the possibility to manually process the suggestions{/ts}">{ts domain='org.project60.banking'}Review transaction{/ts}</a>
         {if $can_delete}<a class="action-item crm-hover-button" onClick="deleteLine({$line.id});">{ts domain='org.project60.banking'}Delete line{/ts}</a>{/if}
       </span></td>
     </tr>
@@ -156,7 +156,7 @@ function processSelected() {
             {literal}
             message = message.replace('_1', data.values.payment_count-data.values.processed_count);
             message = message.replace('_2', data.values.payment_count);
-            cj('<div title="{/literal}{ts domain='org.project60.banking'}Process timed out{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + message + '</div>').dialog({
+            cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Process timed out{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + message + '</div>').dialog({
               modal: true,
               buttons: {
                 Ok: function() { location.reload(); }
@@ -164,7 +164,7 @@ function processSelected() {
             });
           }
         } else {
-          cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+          cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
             modal: true,
             buttons: {
               Ok: function() { location.reload(); }
@@ -200,7 +200,7 @@ function deleteLine(line_id) {
             CRM.alert(message, "info");
             window.setTimeout("location.reload()", 1500);
           } else {
-            cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+            cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
               modal: true,
               buttons: {
                 Ok: function() { location.reload(); }

--- a/templates/CRM/Banking/Page/Statements.tpl
+++ b/templates/CRM/Banking/Page/Statements.tpl
@@ -25,7 +25,7 @@
           <label for="date">{ts domain='org.project60.banking'}Date{/ts}</label>
           <input formattype="searchDate" startoffset="{$date_attributes.startOffset}" endoffset="{$date_attributes.endOffset}" format="{$date_attributes.format}" value="{$date}" name="date" id="date" class="crm-form-text" type="text">
           <input type="text" name="date_display" id="date_display" class="dateplugin" autocomplete="off"/>
-          <a href="#" class="crm-hover-button crm-clear-link" title="{ts domain='org.project60.banking'}Clear{/ts}"><i class="crm-i fa-times"></i></a>
+          <a href="#" class="crm-hover-button crm-clear-link" title="{ts escape='htmlattribute' domain='org.project60.banking'}Clear{/ts}"><i class="crm-i fa-times"></i></a>
           <script type="text/javascript">
             {literal}
             CRM.$(function($) {
@@ -82,7 +82,7 @@
     </table>
 
     <div class="crm-submit-buttons">
-    <input type="submit" class="crm-form-submit" value="{ts domain='org.project60.banking'}Filter{/ts}">
+    <input type="submit" class="crm-form-submit" value="{ts escape='htmlattribute' domain='org.project60.banking'}Filter{/ts}">
     </div>
   </div>
 </form>
@@ -98,7 +98,7 @@
     <th class="sorting_disabled">{ts domain='org.project60.banking'}Amount{/ts}</th>
     <th class="sorting_disabled">{ts domain='org.project60.banking'}Reference{/ts}</th>
     <th class="sorting_disabled">{ts domain='org.project60.banking'}Sequence{/ts}</th>
-    <th class="sorting_disabled" title="{ts domain='org.project60.banking'}(new / suggestions / processed / ignored){/ts}">{ts domain='org.project60.banking'}Transactions{/ts}</th>
+    <th class="sorting_disabled" title="{ts escape='htmlattribute' domain='org.project60.banking'}(new / suggestions / processed / ignored){/ts}">{ts domain='org.project60.banking'}Transactions{/ts}</th>
     <th class="sorting_disabled"></th>
   </tr>
 </thead>
@@ -117,11 +117,11 @@
       <td>{$statement.total|crmMoney:$statement.currency}</td>
       <td>{$statement.reference}</td>
       <td>{$statement.sequence}</td>
-      <td title="{ts domain='org.project60.banking'}(new / suggestions / processed / ignored){/ts}">{$statement.count}<br>
+      <td title="{ts escape='htmlattribute' domain='org.project60.banking'}(new / suggestions / processed / ignored){/ts}">{$statement.count}<br>
         ({$statement.status.new} / {$statement.status.suggestions} / {$statement.status.processed} / {$statement.status.ignored})
       </td>
       <td><span>
-        <a class="action-item crm-hover-button" href="{crmURL p="civicrm/banking/review" q="s_list=`$statement.id`"}" title="{ts domain='org.project60.banking'}Walk through the payments and will show the suggestions and will give you the possibility to manually process the suggestions{/ts}">{ts domain='org.project60.banking'}Review statements{/ts}</a>
+        <a class="action-item crm-hover-button" href="{crmURL p="civicrm/banking/review" q="s_list=`$statement.id`"}" title="{ts escape='htmlattribute' domain='org.project60.banking'}Walk through the payments and will show the suggestions and will give you the possibility to manually process the suggestions{/ts}">{ts domain='org.project60.banking'}Review statements{/ts}</a>
         <a class="action-item crm-hover-button" href="{crmURL p="civicrm/banking/statements/lines" q="s_id=`$statement.id`"}&reset=1">{ts domain='org.project60.banking'}List lines{/ts}</a>
         {if $can_delete}<a class="action-item crm-hover-button" onClick="deleteStatement({$statement.id});">{ts domain='org.project60.banking'}Delete statement{/ts}</a>{/if}
       </span></td>
@@ -173,7 +173,7 @@ function callWithSelected(url, forced) {
     location.href = url.replace("__selected__", selected);
   } else {
     {/literal}
-    var message = "{ts domain='org.project60.banking'}Please select one or more items{/ts}";
+    var message = "{ts escape='htmlattribute' domain='org.project60.banking'}Please select one or more items{/ts}";
     {literal}
     window.alert(message);
   }
@@ -228,7 +228,7 @@ function processSelected() {
             {literal}
             message = message.replace('_1', data.values.payment_count-data.values.processed_count);
             message = message.replace('_2', data.values.payment_count);
-            cj('<div title="{/literal}{ts domain='org.project60.banking'}Process timed out{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + message + '</div>').dialog({
+            cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Process timed out{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + message + '</div>').dialog({
               modal: true,
               buttons: {
                 Ok: function() { location.reload(); }
@@ -236,7 +236,7 @@ function processSelected() {
             });
           }
         } else {
-          cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+          cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
             modal: true,
             buttons: {
               Ok: function() { location.reload(); }
@@ -272,7 +272,7 @@ function deleteStatement(statement_id) {
             CRM.alert(message, "info");
             window.setTimeout("location.reload()", 1500);
           } else {
-            cj('<div title="{/literal}{ts domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
+            cj('<div title="{/literal}{ts escape='htmlattribute' domain='org.project60.banking'}Error{/ts}{literal}"><span class="ui-icon ui-icon-alert" style="float:left;"></span>' + data['error_message'] + '</div>').dialog({
               modal: true,
               buttons: {
                 Ok: function() { location.reload(); }

--- a/templates/CRM/Banking/PluginImpl/Matcher/DefaultOptions.suggestion.tpl
+++ b/templates/CRM/Banking/PluginImpl/Matcher/DefaultOptions.suggestion.tpl
@@ -160,7 +160,7 @@
             if (contact.street_address || contact.city) {
               item_label += " (" + contact.street_address + ", " + contact.city + ")";
             } else {
-              item_label += " ({/literal}{ts domain='org.project60.banking'}unknown address{/ts}{literal})";
+              item_label += " ({/literal}{ts escape='htmlattribute' domain='org.project60.banking'}unknown address{/ts}{literal})";
             }
             hook_label = cj(document).triggerHandler('banking_contact_option_element', [item_label, contact]);
             if (typeof hook_label != 'undefined') {


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.