### PR TITLE
Fix URL syntax for editing banking rules

### DIFF
--- a/templates/CRM/Banking/PluginImpl/Matcher/RulesAnalyser.suggestion.tpl
+++ b/templates/CRM/Banking/PluginImpl/Matcher/RulesAnalyser.suggestion.tpl
@@ -46,7 +46,7 @@
           </td>
           <td>
             {capture assign=rule_id}{$rule.id}{/capture}
-            <a href="{crmURL p="civicrm/a/#/banking/rules/$rule_id}" target="_blank">Edit Rule</a>
+            <a href="{crmURL p="civicrm/a/#/banking/rules/$rule_id"}" target="_blank">Edit Rule</a>
           </td>
           </tr>
           {/if}


### PR DESCRIPTION
Without this fix the following syntax error will be raised:

Syntax error in template "file:CRM/Banking/PluginImpl/Matcher/RulesAnalyser.suggestion.tpl" on line 49 "<a href="{crmURL p="civicrm/a/#/banking/rules/$rule_id}" target="_blank">Edit Rule</a>" - Unexpected "/"