### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Banking/PluginImpl/PostProcessor/MembershipExtension.php
+++ b/CRM/Banking/PluginImpl/PostProcessor/MembershipExtension.php
@@ -405,7 +405,7 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipExtension extends CRM_Banki
    * Create a new membership
    *
    * @param $contribution array contribution data
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   protected function createMembership($contribution, $membership_type_id = NULL) {
     $config = $this->_plugin_config;
@@ -561,7 +561,7 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipExtension extends CRM_Banki
    * @param CRM_Banking_Matcher_Suggestion $match         the executed match
    * @param CRM_Banking_Matcher_Context    $context       context
    * @return array memberships
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   protected function getEligibleMemberships($contribution, $match, $context) {
     $config = $this->_plugin_config;
@@ -687,7 +687,7 @@ class CRM_Banking_PluginImpl_PostProcessor_MembershipExtension extends CRM_Banki
    *
    * @param CRM_Banking_Matcher_Context $context
    * @return array contributions
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   protected function getEligibleContributions($context) {
     $cache_key = "{$this->_plugin_id}_eligiblecontributions_{$context->btx->id}";

--- a/CRM/Banking/PluginImpl/PostProcessor/RecurringFails.php
+++ b/CRM/Banking/PluginImpl/PostProcessor/RecurringFails.php
@@ -184,7 +184,7 @@ class CRM_Banking_PluginImpl_PostProcessor_RecurringFails extends CRM_Banking_Pl
    * @param $mandate_stats
    * @param $context
    * @param $match
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   protected function executeRule($rule, $contribution, $mandate_stats, $context, $match) {
     $this->logMessage("Execute rule '{$rule->name}'...", 'debug');

--- a/CRM/Banking/Rules/Rule.php
+++ b/CRM/Banking/Rules/Rule.php
@@ -218,7 +218,7 @@ class CRM_Banking_Rules_Rule {
     else {
       // Minimal parsing of conditions.
       if (!is_array($params['conditions'])) {
-        throw new API_Exception("Expect conditions parameter to be an object.");
+        throw new CRM_Core_Exception("Expect conditions parameter to be an object.");
       }
       $conditions = $params['conditions'];
     }
@@ -228,7 +228,7 @@ class CRM_Banking_Rules_Rule {
     else {
       // Minimal parsing of execution.
       if (!is_array($params['execution'])) {
-        throw new API_Exception("Expect execution parameter to be an object.");
+        throw new CRM_Core_Exception("Expect execution parameter to be an object.");
       }
       $executions = $params['execution'];
     }

--- a/Civi/Banking/Actions/AddIban.php
+++ b/Civi/Banking/Actions/AddIban.php
@@ -67,7 +67,7 @@ class AddIban extends AbstractAction {
           'reference_type_id' => $ibanAccountReference,
           'ba_id' => $ba['id'],
         ]);
-      } catch (\CiviCRM_API3_Exception $ex) {
+      } catch (\CRM_Core_Exception $ex) {
         throw new ExecutionException(E::ts('Could not add bank account') . $iban . E::ts(' to contact ID ') . $contactId
           . E::ts(', error message from API3 BankingAccount or BankingAccountReference create: ') . $ex->getMessage());
       }
@@ -113,7 +113,7 @@ class AddIban extends AbstractAction {
           return $optionValue['id'];
         }
       }
-      catch (\API_Exception $ex) {
+      catch (\CRM_Core_Exception $ex) {
       }
     }
     else {
@@ -127,7 +127,7 @@ class AddIban extends AbstractAction {
           return $accRef;
         }
       }
-      catch (\CiviCRM_API3_Exception $ex) {
+      catch (\CRM_Core_Exception $ex) {
       }
     }
     return FALSE;

--- a/Civi/Banking/Actions/FindLatestAccount.php
+++ b/Civi/Banking/Actions/FindLatestAccount.php
@@ -62,7 +62,7 @@ class FindLatestAccount extends AbstractAction {
             $output->setParameter('bank_account', $bankAccount);
           }
         }
-      } catch (\CiviCRM_API3_Exception $ex) {
+      } catch (\CRM_Core_Exception $ex) {
         throw new ExecutionException(E::ts('Could not find a bank account for contact') . $contactId
           . E::ts(', error message from API3 BankingAccount or BankingAccountReference getvalue: ') . $ex->getMessage());
       }

--- a/api/v3/BankingPluginInstance/Import.php
+++ b/api/v3/BankingPluginInstance/Import.php
@@ -42,7 +42,7 @@ function _civicrm_api3_banking_plugin_instance_import_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_banking_plugin_instance_import($params) {
   // Security analysis: This API accepts arbitrary file paths and could (indirectly)
@@ -51,7 +51,7 @@ function civicrm_api3_banking_plugin_instance_import($params) {
   // with check_permissions != 0. This is roughly the same security barrier
   // implemented for options.move-file in the Attachment.create API3
   if (!empty($params['check_permissions'])) {
-    throw new API_Exception('API only supported on secure calls');
+    throw new CRM_Core_Exception('API only supported on secure calls');
   }
   $plugin_list = CRM_Banking_BAO_PluginInstance::listInstances('import');
   /**
@@ -64,13 +64,13 @@ function civicrm_api3_banking_plugin_instance_import($params) {
     }
   }
   if (is_null($plugin_instance)) {
-    throw new API_Exception('Unknown plugin id ' . $params['plugin_id']);
+    throw new CRM_Core_Exception('Unknown plugin id ' . $params['plugin_id']);
   }
   if (!$plugin_instance::does_import_files()) {
-    throw new API_Exception('Plugin does not support import files');
+    throw new CRM_Core_Exception('Plugin does not support import files');
   }
   if (!is_readable($params['file_path'])) {
-    throw new API_Exception('file_path is not readable');
+    throw new CRM_Core_Exception('file_path is not readable');
   }
   $import_parameters = [
     'dry_run' => !empty($params['dry_run']) ? 'on' : 'off',
@@ -81,7 +81,7 @@ function civicrm_api3_banking_plugin_instance_import($params) {
     $plugin_instance->import_file($params['file_path'], $import_parameters);
   }
   else {
-    throw new API_Exception('File rejected by importer!');
+    throw new CRM_Core_Exception('File rejected by importer!');
   }
 
   $warnings = [];

--- a/api/v3/BankingRule/Getruledata.php
+++ b/api/v3/BankingRule/Getruledata.php
@@ -19,7 +19,7 @@ function _civicrm_api3_banking_rule_Getruledata_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_banking_rule_Getruledata($params) {
 

--- a/api/v3/BankingRule/Getsearchresults.php
+++ b/api/v3/BankingRule/Getsearchresults.php
@@ -45,7 +45,7 @@ function _civicrm_api3_banking_rule_Getsearchresults_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_banking_rule_Getsearchresults($params) {
   $results = CRM_Banking_Rules_Rule::search($params);

--- a/api/v3/BankingRule/Match.php
+++ b/api/v3/BankingRule/Match.php
@@ -26,7 +26,7 @@ function _civicrm_api3_banking_rule_Match_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_banking_rule_Match($params) {
 
@@ -69,6 +69,6 @@ function civicrm_api3_banking_rule_Match($params) {
       $rule->delete();
     }
 
-    throw new API_Exception($e->getMessage());
+    throw new CRM_Core_Exception($e->getMessage());
   }
 }

--- a/api/v3/BankingRule/Update.php
+++ b/api/v3/BankingRule/Update.php
@@ -40,7 +40,7 @@ function _civicrm_api3_banking_rule_Update_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_banking_rule_Update($params) {
   try {
@@ -71,7 +71,7 @@ function civicrm_api3_banking_rule_Update($params) {
     return civicrm_api3_create_success($result, $params, 'BankingRule', 'Update');
   }
   catch (Exception $e) {
-    throw new API_Exception($e->getMessage());
+    throw new CRM_Core_Exception($e->getMessage());
   }
 
 }

--- a/api/v3/BankingRule/Updatesearchresults.php
+++ b/api/v3/BankingRule/Updatesearchresults.php
@@ -26,7 +26,7 @@ function _civicrm_api3_banking_rule_Updatesearchresults_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_banking_rule_Updatesearchresults($params) {
 


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.