### PR TITLE
Fix order-of-operations from previous commit

### DIFF
--- a/CRM/Banking/PluginImpl/Matcher/RecurringContribution.php
+++ b/CRM/Banking/PluginImpl/Matcher/RecurringContribution.php
@@ -841,7 +841,7 @@ class CRM_Banking_PluginImpl_Matcher_RecurringContribution extends CRM_Banking_P
 
           }
           else {
-            if ($rcur2merge[$key] != $virtual_rcur[$key] ?? NULL) {
+            if ($rcur2merge[$key] != ($virtual_rcur[$key] ?? NULL)) {
               $virtual_rcur[$key] = '';
             }
           }


### PR DESCRIPTION
The ?? operator takes priority over comparison operators so must be surrounded by brackets.