### PR TITLE
Update deprecated php type casts

### DIFF
--- a/CRM/Banking/PluginImpl/Matcher/CreateCampaignContribution.php
+++ b/CRM/Banking/PluginImpl/Matcher/CreateCampaignContribution.php
@@ -102,7 +102,7 @@ class CRM_Banking_PluginImpl_Matcher_CreateCampaignContribution extends CRM_Bank
     $config = $this->_plugin_config;
     $threshold   = $this->getThreshold();
     $penalty     = $this->getPenalty($btx);
-    $activity_with_no_campaign_penalty = (double) $config->activity_with_no_campaign_penalty;
+    $activity_with_no_campaign_penalty = (float) $config->activity_with_no_campaign_penalty;
     $data_parsed = $btx->getDataParsed();
 
     if ($penalty) {

--- a/CRM/Banking/PluginImpl/Matcher/RecurringContribution.php
+++ b/CRM/Banking/PluginImpl/Matcher/RecurringContribution.php
@@ -896,7 +896,7 @@ class CRM_Banking_PluginImpl_Matcher_RecurringContribution extends CRM_Banking_P
     }
 
     // use the mean date as expected date for the virtual rcontribution
-    $mean_date = $sum_date / (double) count($rcontribution_virtual['virtual']);
+    $mean_date = $sum_date / (float) count($rcontribution_virtual['virtual']);
     return $mean_date;
   }
 

--- a/CRM/Banking/Rules/Rule.php
+++ b/CRM/Banking/Rules/Rule.php
@@ -637,7 +637,7 @@ class CRM_Banking_Rules_Rule {
       case 'amount_min':
       case 'amount_max':
         // Floats
-        $this->$prop = (double) $value;
+        $this->$prop = (float) $value;
         break;
 
       default:


### PR DESCRIPTION
In PHP 8.5, non-canonical scalar type casts (boolean|double|integer|binary) are deprecated.

See https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated