### PR TITLE
GP-20324 Fix implicit limit when filtering deleted contacts

### DIFF
--- a/CRM/Banking/Matcher/Context.php
+++ b/CRM/Banking/Matcher/Context.php
@@ -263,6 +263,7 @@ class CRM_Banking_Matcher_Context {
         'is_deleted' => 0,
         'return'     => 'id',
         'sequential' => 1,
+        'options' => ['limit' => 0],
       ]);
       foreach ($result['values'] as $contact) {
         $filtered_list[$contact['id']] = $contact2probablility[$contact['id']];


### PR DESCRIPTION
This fixes an issue in `CRM_Banking_Matcher_Context::filterDeletedContacts` that causes non-deleted contacts to be removed from matches if the number of non-deleted contacts exceeds the default API3 limit of 25.

(`$api3_default_limit_bodycount++;`)