### PR TITLE
Add regex analyser action handler to execute APIv4 actions

### DIFF
--- a/CRM/Banking/PluginImpl/Matcher/RegexAnalyser.php
+++ b/CRM/Banking/PluginImpl/Matcher/RegexAnalyser.php
@@ -90,7 +90,7 @@ class CRM_Banking_PluginImpl_Matcher_RegexAnalyser extends CRM_Banking_PluginMod
   /**
    * execute all the action defined by the rule to the given match
    *
-   * @param array<int|string, list<string>> $matchData
+   * @param array<string, list<string>> $matchData
    *   Matches of preg_match_all().
    *
    * @throws \CRM_Core_Exception

--- a/Civi/Banking/DependencyInjection/Compiler/ExpressionLanguagePass.php
+++ b/Civi/Banking/DependencyInjection/Compiler/ExpressionLanguagePass.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\DependencyInjection\Compiler;
+
+use Civi\Banking\ExpressionLanguage\BankingExpressionFunctionProviderInterface;
+use Civi\Banking\ExpressionLanguage\BankingExpressionLanguage;
+use Civi\Core\ClassScanner;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class ExpressionLanguagePass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container): void {
+    $providerServices = [];
+    foreach (ClassScanner::get(['interface' => BankingExpressionFunctionProviderInterface::class]) as $class) {
+      if (!$container->has($class)) {
+        $container->autowire($class, $class);
+      }
+
+      $providerServices[] = new Reference($class);
+    }
+
+    $container->register(BankingExpressionLanguage::class, BankingExpressionLanguage::class)
+      ->setArguments([NULL, $providerServices]);
+  }
+
+}

--- a/Civi/Banking/ExpressionLanguage/BankingExpressionFunctionProviderInterface.php
+++ b/Civi/Banking/ExpressionLanguage/BankingExpressionFunctionProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+interface BankingExpressionFunctionProviderInterface extends ExpressionFunctionProviderInterface {
+}

--- a/Civi/Banking/ExpressionLanguage/BankingExpressionLanguage.php
+++ b/Civi/Banking/ExpressionLanguage/BankingExpressionLanguage.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+final class BankingExpressionLanguage extends ExpressionLanguage {
+}

--- a/Civi/Banking/ExpressionLanguage/Providers/BankingExpressionLanguageProvider.php
+++ b/Civi/Banking/ExpressionLanguage/Providers/BankingExpressionLanguageProvider.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\ExpressionLanguage\Providers;
+
+use Civi\Banking\ExpressionLanguage\BankingExpressionFunctionProviderInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+
+final class BankingExpressionLanguageProvider implements BankingExpressionFunctionProviderInterface {
+
+  public function getFunctions(): array {
+    return [
+      ExpressionFunction::fromPhp('implode'),
+    ];
+  }
+
+}

--- a/Civi/Banking/Matcher/Helper/Api4ParamsFactory.php
+++ b/Civi/Banking/Matcher/Helper/Api4ParamsFactory.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Webmozart\Assert\Assert;
+
+final class Api4ParamsFactory {
+
+  public function __construct(
+    private readonly ExpressionLanguage $expressionLanguage
+  ) {}
+
+  /**
+   * @phpstan-param object{
+   *   action: string,
+   *   params?: \stdClass,
+   *   result_map?: \stdClass,
+   * } $actionDefinition
+   *
+   * @param array<string, mixed> $expressionValues
+   *
+   * @return array<string, mixed>
+   */
+  public function createParams(
+    object $actionDefinition,
+    array $expressionValues = []
+  ): array {
+    if (property_exists($actionDefinition, 'params')) {
+      Assert::isInstanceOf($actionDefinition->params, \stdClass::class);
+      // Convert \stdClass to array.
+      /** @var array<string, mixed> $params */
+      // @phpstan-ignore argument.type
+      $params = json_decode(json_encode($actionDefinition->params), TRUE);
+    }
+    else {
+      $params = [];
+    }
+
+    if ('get' === $actionDefinition->action && !isset($params['select'])) {
+      if (property_exists($actionDefinition, 'result_map')) {
+        $params['select'] = [];
+        Assert::isInstanceOf($actionDefinition->result_map, \stdClass::class);
+        $resultMap = (array) $actionDefinition->result_map;
+        foreach ($resultMap as $source) {
+          if (is_string($source)) {
+            $fieldNameOrExpression = $source;
+          }
+          else {
+            Assert::notNull($source->field, 'Source field name in result map is missing');
+            Assert::string($source->field, 'Expected string as source field name in result map, got %s');
+            $fieldNameOrExpression = $source->field;
+          }
+
+          if (str_starts_with($fieldNameOrExpression, '@=')) {
+            $params['select'] = [];
+            break;
+          }
+
+          $params['select'][] = $fieldNameOrExpression;
+        }
+      }
+    }
+
+    self::evaluateExpressions($params, $expressionValues);
+
+    return $params;
+  }
+
+  /**
+   * Recursively evaluate and replace expressions, i.e. values starting with
+   * "@=".
+   *
+   * @param array<mixed> $array
+   * @param array<int|string, mixed> $expressionValues
+   */
+  private function evaluateExpressions(array &$array, array $expressionValues): void {
+    foreach ($array as &$value) {
+      if (is_array($value)) {
+        self::evaluateExpressions($value, $expressionValues);
+      }
+      elseif (is_string($value) && str_starts_with($value, '@=')) {
+        $expression = substr($value, 2);
+        $value = $this->expressionLanguage->evaluate($expression, $expressionValues);
+      }
+    }
+  }
+
+}

--- a/Civi/Banking/Matcher/Helper/Api4ParamsFactory.php
+++ b/Civi/Banking/Matcher/Helper/Api4ParamsFactory.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Civi\Banking\ExpressionLanguage\BankingExpressionLanguage;
+use Webmozart\Assert\Assert;
+
+/**
+ * @phpstan-import-type resultMapOptionsT from Api4ResultMapOptions
+ *
+ * @phpstan-type actionDefinitionT object{
+ *   action: string,
+ *   params?: \stdClass,
+ *   result_map?: \stdClass,
+ *   result_map_options?: resultMapOptionsT,
+ * }
+ */
+final class Api4ParamsFactory {
+
+  public function __construct(
+    private readonly BankingExpressionLanguage $expressionLanguage
+  ) {}
+
+  /**
+   * @phpstan-param actionDefinitionT $actionDefinition
+   * @param array<string, mixed> $expressionValues
+   *
+   * @return array<string, mixed>
+   */
+  public function createParams(
+    object $actionDefinition,
+    array $expressionValues = []
+  ): array {
+    if (property_exists($actionDefinition, 'params')) {
+      Assert::isInstanceOf($actionDefinition->params, \stdClass::class);
+      // Convert \stdClass to array.
+      /** @var array<string, mixed> $params */
+      // @phpstan-ignore argument.type
+      $params = json_decode(json_encode($actionDefinition->params), TRUE);
+    }
+    else {
+      $params = [];
+    }
+
+    $this->determineSelectAndLimit($params, $actionDefinition);
+    $this->evaluateExpressions($params, $expressionValues);
+
+    return $params;
+  }
+
+  /**
+   * @param array<string, mixed> $params
+   * @phpstan-param actionDefinitionT $actionDefinition
+   */
+  private function determineSelectAndLimit(array &$params, object $actionDefinition): void {
+    $resultMapOptions = Api4ResultMapOptions::fromObject($actionDefinition->result_map_options ?? NULL);
+    if (
+      'get' === $actionDefinition->action
+      && property_exists($actionDefinition, 'result_map')
+      && (
+        !isset($params['select'])
+        || !isset($params['limit']) && !$resultMapOptions->useAllResults
+      )
+    ) {
+      $select = [];
+      if (NULL !== $resultMapOptions->indexBy) {
+        $select[] = $resultMapOptions->indexBy;
+      }
+
+      $resultMapHasExpression = FALSE;
+      Assert::isInstanceOf($actionDefinition->result_map, \stdClass::class);
+      $resultMap = (array) $actionDefinition->result_map;
+      foreach ($resultMap as $fieldNameOrExpression) {
+        Assert::string($fieldNameOrExpression, 'APIv4 field name or expression expected in result map, got %s');
+        if (str_starts_with($fieldNameOrExpression, '@=')) {
+          // Select all fields if an expression is used.
+          $select = [];
+          $resultMapHasExpression = TRUE;
+          break;
+        }
+
+        $select[] = $fieldNameOrExpression;
+      }
+
+      $params['select'] ??= $select;
+
+      if (!$resultMapOptions->useAllResults && !$resultMapHasExpression) {
+        $params['limit'] ??= 1;
+      }
+    }
+  }
+
+  /**
+   * Recursively evaluate and replace expressions, i.e. values starting with
+   * "@=".
+   *
+   * @param array<mixed> $array
+   * @param array<int|string, mixed> $expressionValues
+   */
+  private function evaluateExpressions(array &$array, array $expressionValues): void {
+    foreach ($array as &$value) {
+      if (is_array($value)) {
+        $this->evaluateExpressions($value, $expressionValues);
+      }
+      elseif (is_string($value) && str_starts_with($value, '@=')) {
+        $expression = substr($value, 2);
+        $value = $this->expressionLanguage->evaluate($expression, $expressionValues);
+      }
+    }
+  }
+
+}

--- a/Civi/Banking/Matcher/Helper/Api4ResultMapOptions.php
+++ b/Civi/Banking/Matcher/Helper/Api4ResultMapOptions.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+/**
+ * @phpstan-type resultMapOptionsT object{
+ *      use_all_results?: bool,
+ *      index_by?: string,
+ *      skip_empty_result?: bool,
+ *    }&\stdClass
+ */
+final class Api4ResultMapOptions {
+
+  /**
+   * @phpstan-param ?resultMapOptionsT $action
+   */
+  public static function fromObject(?\stdClass $action): self {
+    return new self(
+      $action->use_all_results ?? FALSE,
+      $action->index_by ?? NULL,
+      $action->skip_empty_result ?? TRUE,
+    );
+  }
+
+  public function __construct(
+    public bool $useAllResults = FALSE,
+    public ?string $indexBy = NULL,
+    public bool $skipEmptyResult = TRUE,
+  ) {}
+
+}

--- a/Civi/Banking/Matcher/Helper/Api4ResultMapper.php
+++ b/Civi/Banking/Matcher/Helper/Api4ResultMapper.php
@@ -1,0 +1,122 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Civi\Api4\Generic\Result;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Webmozart\Assert\Assert;
+
+/**
+ * @phpstan-type resultMapT array<string, string|object{
+ *   field: string,
+ *   filter?: 'first'|'last',
+ *   value_separator?: string,
+ * }>
+ */
+final class Api4ResultMapper {
+
+  public function __construct(
+    private readonly ExpressionLanguage $expressionLanguage
+  ) {}
+
+  /**
+   * @phpstan-param resultMapT $resultMap
+   *   Mapping of target field name to an APIv4 field name, an expression or an
+   *   object containing the APIv4 field name.
+   * @param callable(string, mixed): void $setValueCallback
+   */
+  public function mapResult(Result $result, array $resultMap, callable $setValueCallback): void {
+    if (0 === $result->countFetched()) {
+      return;
+    }
+
+    foreach ($resultMap as $to => $from) {
+      if (!is_string($from) && !$from instanceof \stdClass) {
+        throw new \InvalidArgumentException(sprintf('Invalid source definition for field "%s" in result map', $to));
+      }
+
+      $setValueCallback($to, $this->getValue($result, $from));
+    }
+  }
+
+  private function applyFilter(mixed $value, string $filter): mixed {
+    if ('first' === $filter) {
+      if (is_array($value)) {
+        return [] === $value ? NULL : reset($value);
+      }
+
+      return $value;
+    }
+
+    if ('last' === $filter) {
+      if (is_array($value)) {
+        return [] === $value ? NULL : end($value);
+      }
+
+      return $value;
+    }
+
+    throw new \InvalidArgumentException(sprintf('Unknown filter "%s"', $filter));
+  }
+
+  private function applyModifications(mixed $value, \stdClass $source): mixed {
+    if (property_exists($source, 'filter')) {
+      Assert::string('Filter has to be a string in source definition of result map');
+      $value = $this->applyFilter($value, $source->filter);
+    }
+
+    return $value;
+  }
+
+  private function getValue(Result $result, string|\stdClass $source): mixed {
+    if (is_string($source)) {
+      if (str_starts_with($source, '@=')) {
+        return $this->getValueForExpression($result, substr($source, 2));
+      }
+
+      return $this->getValueForFieldName($result, $source);
+    }
+
+    $fieldName = $source->field;
+    Assert::notNull($fieldName, 'Source field name in result map is missing');
+    Assert::string($fieldName, 'Expected string as source field name in result map, got %s');
+
+    $valueSeparator = $source->value_separator ?? ',';
+    Assert::string($valueSeparator, 'Expected string as value separator in result map, got %s');
+
+    return $this->applyModifications(
+      $this->getValueForFieldName($result, $fieldName, $valueSeparator),
+      $source
+    );
+  }
+
+  private function getValueForExpression(Result $result, string $expression): mixed {
+    return $this->expressionLanguage->evaluate($expression, ['result' => $result]);
+  }
+
+  private function getValueForFieldName(Result $result, string $fieldName, string $valueSeparator = ','): mixed {
+    return match ($result->countFetched()) {
+      1 => $result->single()[$fieldName],
+      default => implode($valueSeparator, $result->column($fieldName)),
+    };
+  }
+
+}

--- a/Civi/Banking/Matcher/Helper/Api4ResultMapper.php
+++ b/Civi/Banking/Matcher/Helper/Api4ResultMapper.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Civi\Api4\Generic\Result;
+use Civi\Banking\ExpressionLanguage\BankingExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class Api4ResultMapper {
+
+  public function __construct(
+    private readonly BankingExpressionLanguage $expressionLanguage
+  ) {}
+
+  /**
+   * @phpstan-param array<string, string> $resultMap
+   *   Mapping of target field to an APIv4 field name or an expression starting with "@=".
+   *
+   * @return iterable<string, mixed>
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function applyResultMap(Result $result, array $resultMap, Api4ResultMapOptions $options): iterable {
+    if (0 === $result->countFetched() && $options->skipEmptyResult) {
+      return;
+    }
+
+    if (NULL !== $options->indexBy) {
+      $result->indexBy($options->indexBy);
+    }
+
+    foreach ($resultMap as $to => $from) {
+      yield $to => $this->getValue($result, $options, $from);
+    }
+  }
+
+  private function getValue(Result $result, Api4ResultMapOptions $options, string $fieldNameOrExpression): mixed {
+    if (str_starts_with($fieldNameOrExpression, '@=')) {
+      return $this->getValueForExpression($result, substr($fieldNameOrExpression, 2));
+    }
+
+    return $this->getValueForFieldName($result, $options, $fieldNameOrExpression);
+  }
+
+  private function getValueForExpression(Result $result, string $expression): mixed {
+    return $this->expressionLanguage->evaluate($expression, ['result' => $result]);
+  }
+
+  private function getValueForFieldName(Result $result, Api4ResultMapOptions $options, string $fieldName): mixed {
+    return $options->useAllResults ? $result->column($fieldName) : ($result->first()[$fieldName] ?? NULL);
+  }
+
+}

--- a/Civi/Banking/Matcher/Helper/ExpressionLanguageValuesGenerator.php
+++ b/Civi/Banking/Matcher/Helper/ExpressionLanguageValuesGenerator.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Webmozart\Assert\Assert;
+
+final class ExpressionLanguageValuesGenerator {
+
+  /**
+   * Generates a values array for use in Symfony Expression Language to access
+   * values in expressions via e.g. "btx.amount" or "btx['my.value']". (For keys
+   * containing dots or special characters, array access has to be used.)
+   *
+   * @param list<string> $prefixes
+   *   List of prefixes, e.g. "btx" or "ba".
+   * @param callable(string): mixed $getValueCallback
+   *
+   * @return array<string, object>
+   */
+  public static function generateValuesForPrefixes(array $prefixes, callable $getValueCallback): array {
+    $values = [];
+    foreach ($prefixes as $prefix) {
+      $values[$prefix] = self::createValueWrapper($prefix, $getValueCallback);
+    }
+
+    return $values;
+  }
+
+  /**
+   * @param callable(string): mixed $getValueCallback
+   */
+  private static function createValueWrapper(string $prefix, callable $getValueCallback): object {
+    return new class ($prefix, $getValueCallback(...)) implements \ArrayAccess {
+
+      /**
+       * @param \Closure(string): mixed $getValueCallback
+       */
+      public function __construct(
+        private readonly string $prefix,
+        private readonly \Closure $getValueCallback,
+      ) {}
+
+      public function __get(string $name): mixed {
+        return ($this->getValueCallback)($this->prefix . '.' . $name);
+      }
+
+      public function offsetExists(mixed $offset): bool {
+        Assert::string($offset);
+        return NULL !== ($this->getValueCallback)($this->prefix . '.' . $offset);
+      }
+
+      public function offsetGet(mixed $offset): mixed {
+        Assert::string($offset);
+
+        return ($this->getValueCallback)($this->prefix . '.' . $offset);
+      }
+
+      public function offsetSet(mixed $offset, mixed $value): void {
+        throw new \BadMethodCallException('Unsupported method');
+      }
+
+      public function offsetUnset(mixed $offset): void {
+        throw new \BadMethodCallException('Unsupported method');
+      }
+
+    };
+  }
+
+}

--- a/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandler.php
+++ b/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandler.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\RegexAnalyser\ActionHandlers;
+
+use Civi\Banking\Matcher\Helper\Api4ParamsFactory;
+use Civi\Banking\Matcher\Helper\Api4ResultMapper;
+use Civi\Banking\Matcher\Helper\ExpressionLanguageValuesGenerator;
+use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserActionHandlerInterface;
+use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext;
+use Webmozart\Assert\Assert;
+
+final class Api4RegexAnalyserActionHandler implements RegexAnalyserActionHandlerInterface {
+
+  public const NAME = 'api4';
+
+  private Api4ParamsFactory $paramFactory;
+
+  private Api4ResultMapper $resultMapper;
+
+  /**
+   * @var \Closure(string, string, array<string, mixed>): \Civi\Api4\Generic\Result
+   */
+  private \Closure $api4Callback;
+
+  /**
+   * @param null|callable(string, string, array<string, mixed>): \Civi\Api4\Generic\Result $api4Callback
+   */
+  public function __construct(Api4ParamsFactory $paramFactory, Api4ResultMapper $resultMapper, ?callable $api4Callback = NULL) {
+    $this->paramFactory = $paramFactory;
+    $this->resultMapper = $resultMapper;
+    $this->api4Callback = ($api4Callback ?? 'civicrm_api4')(...);
+  }
+
+  /**
+   * @param \stdClass $action
+   * @param \Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext $matchContext
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function execute(\stdClass $action, RegexAnalyserMatchContext $matchContext): void {
+    $api4 = $action->api4;
+
+    $entityName = $api4->entity ?? NULL;
+    Assert::notNull($entityName, 'Entity name is missing');
+    Assert::string($entityName, 'Entity name has to be a string, got %s');
+    $actionName = $api4->action ?? NULL;
+    Assert::notNull($actionName, 'Action name is missing');
+    Assert::string($actionName, 'Action name has to be a string, got %s');
+
+    $params = $this->paramFactory->createParams(
+      $api4,
+      ExpressionLanguageValuesGenerator::generateValuesForPrefixes(
+        ['btx', 'ba', 'party_ba'],
+        fn(string $key) => $matchContext->getValue($key)
+      ) + $matchContext->getMatchedValues()
+    );
+
+    /** @throws \CRM_Core_Exception */
+    $result = ($this->api4Callback)($entityName, $actionName, $params);
+
+    if (property_exists($api4, 'result_map')) {
+      Assert::isInstanceOf($api4->result_map, \stdClass::class, 'Result map has to be an object, got %s');
+      $this->resultMapper->mapResult(
+        $result,
+        (array) $api4->result_map,
+        fn($key, $value) => $matchContext->setValue($key, $value)
+      );
+    }
+  }
+
+}

--- a/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandler.php
+++ b/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandler.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\RegexAnalyser\ActionHandlers;
+
+use Civi\Banking\Matcher\Helper\Api4ParamsFactory;
+use Civi\Banking\Matcher\Helper\Api4ResultMapOptions;
+use Civi\Banking\Matcher\Helper\Api4ResultMapper;
+use Civi\Banking\Matcher\Helper\ExpressionLanguageValuesGenerator;
+use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserActionHandlerInterface;
+use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext;
+use Webmozart\Assert\Assert;
+
+/**
+ * Execute any APIv4 action.
+ */
+final class Api4RegexAnalyserActionHandler implements RegexAnalyserActionHandlerInterface {
+
+  public const NAME = 'api4';
+
+  private Api4ParamsFactory $paramFactory;
+
+  private Api4ResultMapper $resultMapper;
+
+  /**
+   * @var \Closure(string, string, array<string, mixed>): \Civi\Api4\Generic\Result
+   */
+  private \Closure $api4Callback;
+
+  /**
+   * @param null|callable(string, string, array<string, mixed>): \Civi\Api4\Generic\Result $api4Callback
+   */
+  public function __construct(Api4ParamsFactory $paramFactory, Api4ResultMapper $resultMapper, ?callable $api4Callback = NULL) {
+    $this->paramFactory = $paramFactory;
+    $this->resultMapper = $resultMapper;
+    $this->api4Callback = ($api4Callback ?? 'civicrm_api4')(...);
+  }
+
+  /**
+   * @param \stdClass $action
+   * @param \Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext $matchContext
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function execute(\stdClass $action, RegexAnalyserMatchContext $matchContext): void {
+    $api4 = $action->api4;
+
+    $entityName = $api4->entity ?? NULL;
+    Assert::notNull($entityName, 'Entity name is missing');
+    Assert::string($entityName, 'Entity name has to be a string, got %s');
+    $actionName = $api4->action ?? NULL;
+    Assert::notNull($actionName, 'Action name is missing');
+    Assert::string($actionName, 'Action name has to be a string, got %s');
+
+    $params = $this->paramFactory->createParams(
+      $api4,
+      ExpressionLanguageValuesGenerator::generateValuesForPrefixes(
+        ['btx', 'ba', 'party_ba'],
+        fn(string $key) => $matchContext->getValue($key)
+      ) + $matchContext->getMatchedValues()
+    );
+
+    /** @throws \CRM_Core_Exception */
+    $result = ($this->api4Callback)($entityName, $actionName, $params);
+
+    if (property_exists($api4, 'result_map')) {
+      Assert::isInstanceOf($api4->result_map, \stdClass::class, 'Result map has to be an object, got %s');
+      $resultMap = (array) $api4->result_map;
+      $resultMapOptions = Api4ResultMapOptions::fromObject($api4->result_map_options ?? NULL);
+      foreach ($this->resultMapper->applyResultMap($result, $resultMap, $resultMapOptions) as $key => $value) {
+        $matchContext->setValue($key, $value);
+      };
+    }
+  }
+
+}

--- a/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/ApiRegexAnalyserActionHandler.php
+++ b/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/ApiRegexAnalyserActionHandler.php
@@ -36,6 +36,8 @@ use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext;
  *  further attributes can be given as follows:
  *   const_<param>    set the API parameter to a constant, e.g. const_contact_type = 'Individual'
  *   param_<param>    set the API parameter to the value of another field, e.g. const_first_name = 'first_name'
+ *
+ * Note: There is also the {@link Api4RegexAnalyserActionHandler} available.
  */
 final class ApiRegexAnalyserActionHandler implements RegexAnalyserActionHandlerInterface {
 

--- a/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/LookupRegexAnalyserActionHandler.php
+++ b/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/LookupRegexAnalyserActionHandler.php
@@ -25,6 +25,8 @@ use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext;
 
 /**
  * LOOK UP values via API::getsingle.
+ *
+ *  Note: There is also the {@link Api4RegexAnalyserActionHandler} available.
  */
 final class LookupRegexAnalyserActionHandler implements RegexAnalyserActionHandlerInterface {
 

--- a/Civi/Banking/Matcher/RegexAnalyser/RegexAnalyserMatchContext.php
+++ b/Civi/Banking/Matcher/RegexAnalyser/RegexAnalyserMatchContext.php
@@ -20,10 +20,10 @@ declare(strict_types = 1);
 
 namespace Civi\Banking\Matcher\RegexAnalyser;
 
-final class RegexAnalyserMatchContext {
+class RegexAnalyserMatchContext {
 
   /**
-   * @param array<int|string, list<string>> $matchData
+   * @param array<string, list<string>> $matchData
    *   Matches of preg_match_all().
    */
   public function __construct(
@@ -87,6 +87,13 @@ final class RegexAnalyserMatchContext {
     return $this->matchData[$key][$this->matchIndex] ?? NULL;
   }
 
+  /**
+   * @return array<string, string>
+   */
+  public function getMatchedValues(): array {
+    return array_map(fn (array $values) => $values[$this->matchIndex], $this->matchData);
+  }
+
   public function getParsedValue(string $key): mixed {
     return $this->btx->getDataParsed()[$key] ?? NULL;
   }
@@ -99,6 +106,32 @@ final class RegexAnalyserMatchContext {
 
   public function setParsedValue(string $key, mixed $value): void {
     $this->btx->setDataParsed([$key => $value] + $this->btx->getDataParsed());
+  }
+
+  public function setValue(string $key, mixed $value): void {
+    [$keyPrefix, $key] = explode('.', $key, 2) + ['', NULL];
+    if (NULL === $key) {
+      $key = $keyPrefix;
+      $keyPrefix = 'btx';
+    }
+
+    if ('ba' === $keyPrefix) {
+      $data = $this->btx->getBankAccount()?->getDataParsed();
+      if (NULL !== $data) {
+        $data[$key] = $value;
+        $this->btx->getBankAccount()->setDataParsed($data);
+      }
+    }
+    elseif ('party_ba' === $keyPrefix) {
+      $data = $this->btx->getPartyBankAccount()?->getDataParsed();
+      if (NULL !== $data) {
+        $data[$key] = $value;
+        $this->btx->getPartyBankAccount()->setDataParsed($data);
+      }
+    }
+    else {
+      $this->setParsedValue($key, $value);
+    }
   }
 
   /**

--- a/banking.php
+++ b/banking.php
@@ -23,9 +23,12 @@ require_once 'banking_options.php';
 
 use Civi\Banking\DependencyInjection\Compiler\ActionProviderPass;
 use Civi\Banking\DependencyInjection\Compiler\RegexAnalyserActionHandlerPass;
+use Civi\Banking\Matcher\Helper\Api4ParamsFactory;
+use Civi\Banking\Matcher\Helper\Api4ResultMapper;
 use Civi\Core\ClassScanner;
 use CRM_Banking_ExtensionUtil as E;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * Implements hook_civicrm_container().
@@ -33,6 +36,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 function banking_civicrm_container(ContainerBuilder $container): void {
   $container->addCompilerPass(new ActionProviderPass());
   $container->addCompilerPass(new RegexAnalyserActionHandlerPass());
+
+  $container->autowire(ExpressionLanguage::class);
+  $container->autowire(Api4ParamsFactory::class);
+  $container->autowire(Api4ResultMapper::class);
 }
 
 /**

--- a/banking.php
+++ b/banking.php
@@ -22,23 +22,38 @@ require_once 'banking_options.php';
 // phpcs:enable
 
 use Civi\Banking\DependencyInjection\Compiler\ActionProviderPass;
+use Civi\Banking\DependencyInjection\Compiler\ExpressionLanguagePass;
 use Civi\Banking\DependencyInjection\Compiler\RegexAnalyserActionHandlerPass;
+use Civi\Banking\Matcher\Helper\Api4ParamsFactory;
+use Civi\Banking\Matcher\Helper\Api4ResultMapper;
 use Civi\Core\ClassScanner;
 use CRM_Banking_ExtensionUtil as E;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+function _banking_composer_autoload(): void {
+  if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+  }
+}
 
 /**
  * Implements hook_civicrm_container().
  */
 function banking_civicrm_container(ContainerBuilder $container): void {
+  _banking_composer_autoload();
   $container->addCompilerPass(new ActionProviderPass());
+  $container->addCompilerPass(new ExpressionLanguagePass());
   $container->addCompilerPass(new RegexAnalyserActionHandlerPass());
+
+  $container->autowire(Api4ParamsFactory::class);
+  $container->autowire(Api4ResultMapper::class);
 }
 
 /**
  * Implements hook_civicrm_config().
  */
-function banking_civicrm_config(\CRM_Core_Config $config) {
+function banking_civicrm_config(\CRM_Core_Config $config): void {
+  _banking_composer_autoload();
   _banking_civix_civicrm_config($config);
 }
 
@@ -90,6 +105,8 @@ function banking_civicrm_pageRun(&$page) {
 function banking_civicrm_scanClasses(array &$classes): void {
   // @phpstan-ignore parameterByRef.type
   ClassScanner::scanFolders($classes, __DIR__, 'Civi/Banking/Matcher', '\\');
+  // @phpstan-ignore parameterByRef.type
+  ClassScanner::scanFolders($classes, __DIR__, 'Civi/Banking/ExpressionLanguage', '\\');
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": "^8.1",
         "civicrm/civicrm-core": ">=5.76",
         "civicrm/civicrm-packages": ">=5.76",
+        "symfony/expression-language": "^5.4 || ^6 || ^7",
         "webmozart/assert": "^1 || ^2"
     },
     "autoload": {

--- a/docs/configuration/plugins/analyser-matcher.md
+++ b/docs/configuration/plugins/analyser-matcher.md
@@ -95,12 +95,13 @@ flavour.
 ### Regex Analyser Actions
 
 * [`align_date`](#align_date-action) - aligns a date forwards or backwards
-* [`api`](#api-action) - use any CiviCRM API3
+* [`api`](#api-action) - execute any CiviCRM APIv3 action (legacy, use [`api4`](#api4-action) instead)
+* [`api4`](#api4-action) - execute any CiviCRM APIv4 action
 * [`calculate`](#calculate-action) - runs a PHP expression (CAUTION!)
 * [`copy`](#copy-action) - copies a field value
 * [`copy_append`](#copy_append-action) - appends the value to an existing field
 * [`copy_ltrim_zeros`](#copy_ltrim_zeros-action) - removes leading zeros
-* [`lookup`](#lookup-action) - look up a value via `getsingle` APIv3 action
+* [`lookup`](#lookup-action) - look up a value via `getsingle` APIv3 action (legacy, use [`api4`](#api4-action) instead)
 * [`map`](#map-action) - maps from the matched value to a new value
 * [`preg_replace`](#preg_replace-action) - substitutes part of the string using a regular expression
 * [`set`](#set-action) - sets an attribute to a specified value
@@ -197,8 +198,10 @@ Skip the 1st of April as `receive_date`:
 
 #### `api` Action
 
-The `api` Action allows you to call any CiviCRM API version 3 with any action 
-and set the result(s) to one or more fields in the transaction data. 
+Note: This is a legacy action. Consider using the [`api4`](#api4-action) instead.
+
+The `api` action allows you to call any CiviCRM API version 3 with any action
+and set the result(s) to one or more fields in the transaction data.
 
 In contrast to the `lookup` action, the `api` action can also call actions 
 other than `getsingle`. Therefor it is possible to retrieve multiple results,
@@ -258,6 +261,112 @@ searches for the words `memory` or `honor` followed by `John Doe` in the
 type `Memorial` for the donor. The return value of the API call is the ID of 
 the newly created activity, which is set to the `btx.activity_id` field but 
 isn't used any further.
+
+#### `api4` Action
+
+The `api4` action allows to execute any
+[CiviCRM APIv4 action](https://docs.civicrm.org/dev/en/latest/api/v4/usage/)
+and map the result to the transaction data.
+
+You might want to use the APIv4 explorer at URL path `/civicrm/api4` to build
+and test the action and then transfer it to the configuration.
+
+##### Parameters
+
+* `"api4"` - Contains the following parameters:
+  * `"entity"` - The APIv4 entity, e.g. `"Contact"`.
+  * `"action"` - The entity action, e.g. `"get"`.
+  * `"params"` - The APIv4 action parameters. It's possible to access values
+    from the matched pattern or transaction data e.g. `@=named_pattern` or
+    `@=btx.purpose`. A string starting with `@=` is interpreted as expression.
+    Expressions are explained below.
+  * `"result_map"` - Allows to map APIv4 result data into transaction data. The
+    keys are the target field (e.g. `"btx.contact_id"`) and the values are APIv4
+    result fields (e.g. `"id"`) or expressions to retrieve the required value
+    from the result object (e.g. `"@=result.first()['contact_sub_type'][0] ?? NULL"`). Expressions are explained below.
+  * `"result_map_options"` - Options for the `result_map`:
+    * `"use_all_results"` - `true` to retrieve all values of a field as array,
+      otherwise only the value of the first result is used. (Default: `false`)
+    * `"index_by"` - An APIv4 field name the resulting array is indexed by when
+      `use_all_results` is enabled or the `column()` method is used in an
+      expression (e.g. `"@=result.column('some_field')"`).
+    * `"skip_empty_result"` - `false` to set `NULL` or the expression result to
+       the transaction data, if the APIv4 call returned an empty result. By
+       default, the transaction data is unchanged in that case.
+
+If the `result_map` contains no expression and the called action is `get` the
+APIv4 parameters `select` and `limit` will be determined automatically, if not
+specified.
+
+Apart from `btx` data can be read from fields of `ba` and `party_ba`, if they
+have been determined before.
+
+##### Example
+<a id="api4-example"></a>
+
+```json
+{
+  "comment": "Look for previous contributions with matching bank name and amount",
+  "fields": [
+    "bank_name"
+  ],
+  "pattern": "/.+/",
+  "action": "api4",
+  "api4": {
+    "entity": "Contribution",
+    "action": "get",
+    "params": {
+      "select": ["id", "financial_type_id"],
+      "orderBy": {
+        "receive_date": "DESC"
+      },
+      "where": [
+        [
+          "Donor_Information.Bank_Name",
+          "=",
+          "@=btx.bank_name"
+        ],
+        [
+          "total_amount",
+          "=",
+          "@=btx.amount"
+        ]
+      ]
+    },
+    "result_map": {
+      "btx.previous_contribution_ids": "@=implode(',', result.column()['id'])",
+      "btx.financial_type_id": "financial_type_id"
+    },
+    "result_map_options": {
+      "skip_empty_result": false
+    }
+  }
+}
+```
+
+In this example all contributions where the custom field
+`Donor_Information.Bank_Name` is equal to the `bank_name` field in the
+transaction data and the `total_amount` is equal to the `amount` in the
+transaction data are fetched in descendant order by `receive_date`.
+
+The IDs of the fetched contribution will be set comma-separated in
+`btx.previous_contribution_ids` and the `financial_type_id` of the first fetched
+contribution (i.e. the matching contribution with the latest `receive_date`)
+will be set in `btx.financial_type_id`.
+
+Because the result map option `skip_empty_result` is set to `false`, an empty
+array will be set to `btx.previous_contribution_ids` and `NULL` will be set to
+`btx.financial_type_id`, if no matching contribution is found.
+
+##### Expressions
+
+Strings starting with `@=` in the APIv4 `params` and the `result_map` are
+interpreted using the Symfony Expression Language. So there are many more
+possibilities available than used in the [example](#api4-example) above. Please
+have a look at the
+[syntax documentation](https://symfony.com/doc/current/reference/formats/expression_language.html)
+for more details. Additionally, the function `implode()` is available (see the
+[example](#api4-example)).
 
 #### `calculate` Action
 
@@ -350,6 +459,8 @@ the value of the `bank_account_number` field to the `bank_account_number` field
 and removes the leading zeros.
 
 #### `lookup` Action
+
+Note: This is a legacy action consider using the [`api4`](#api4-action) instead.
 
 The `lookup` action allows you to look up a CiviCRM API entity based on a given
 parameter. The action can be used to look up any CiviCRM APIv3 entity, but it 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -163,12 +163,6 @@ parameters:
 			path: CRM/Banking/BAO/BankAccount.php
 
 		-
-			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Banking/BAO/BankAccount.php
-
-		-
 			message: '#^Property CRM_Banking_BAO_BankAccount\:\:\$_decoded_data_parsed has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -266,12 +260,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$v of method DB_DataObject\:\:get\(\) expects string\|null, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Banking/BAO/BankAccountReference.php
-
-		-
-			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: CRM/Banking/BAO/BankAccountReference.php
@@ -493,12 +481,6 @@ parameters:
 			path: CRM/Banking/BAO/BankTransaction.php
 
 		-
-			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Banking/BAO/BankTransaction.php
-
-		-
 			message: '#^Property CRM_Banking_BAO_BankTransaction\:\:\$_decoded_data_parsed has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -549,12 +531,6 @@ parameters:
 		-
 			message: '#^Method CRM_Banking_BAO_BankTransactionBatch\:\:getTransactions\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Banking/BAO/BankTransactionBatch.php
-
-		-
-			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: CRM/Banking/BAO/BankTransactionBatch.php
 
@@ -626,12 +602,6 @@ parameters:
 		-
 			message: '#^Method CRM_Banking_BAO_BankTransactionContribution\:\:linkContribution\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: CRM/Banking/BAO/BankTransactionContribution.php
-
-		-
-			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: CRM/Banking/BAO/BankTransactionContribution.php
 
@@ -776,12 +746,6 @@ parameters:
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 2
-			path: CRM/Banking/BAO/PluginInstance.php
-
-		-
-			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
 			path: CRM/Banking/BAO/PluginInstance.php
 
 		-
@@ -12010,12 +11974,6 @@ parameters:
 		-
 			message: '#^Function banking_civicrm_banking_transaction_summary\(\) has parameter \$summary_blocks with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: banking.php
-
-		-
-			message: '#^Function banking_civicrm_config\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: banking.php
 

--- a/tests/phpunit/Civi/Banking/Api4Mock.php
+++ b/tests/phpunit/Civi/Banking/Api4Mock.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking;
+
+use Civi\Api4\Generic\Result;
+
+class Api4Mock {
+
+  /**
+   * @param array<string, mixed> $params
+   */
+  public function __invoke(string $entity, string $action, array $params = []): Result {
+    throw new \BadMethodCallException('Has to be mocked');
+  }
+
+}

--- a/tests/phpunit/Civi/Banking/Matcher/Helper/Api4ParamsFactoryTest.php
+++ b/tests/phpunit/Civi/Banking/Matcher/Helper/Api4ParamsFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Civi\Banking\ExpressionLanguage\BankingExpressionLanguage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Banking\Matcher\Helper\Api4ParamsFactory
+ */
+final class Api4ParamsFactoryTest extends TestCase {
+
+  private Api4ParamsFactory $paramsFactory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->paramsFactory = new Api4ParamsFactory(new BankingExpressionLanguage());
+  }
+
+  public function testDefault(): void {
+    $actionDefinition = (object) [
+      'entity' => 'SomeEntity',
+      'action' => 'get',
+      'params' => (object) [
+        'where' => [
+          ['foo', '=', 'bar'],
+        ],
+      ],
+      'result_map' => (object) [
+        'btx.some_value' => 'baz',
+      ],
+    ];
+
+    static::assertEquals([
+      'where' => [['foo', '=', 'bar']],
+      'select' => ['baz'],
+      'limit' => 1,
+    ], $this->paramsFactory->createParams($actionDefinition));
+  }
+
+  public function testNotGet(): void {
+    $actionDefinition = (object) [
+      'entity' => 'SomeEntity',
+      'action' => 'someAction',
+      'params' => (object) [
+        'foo' => 'bar',
+      ],
+      'result_map' => (object) [
+        'btx.some_value' => 'baz',
+      ],
+    ];
+
+    // 'select' and 'limit' are not set.
+    static::assertEquals([
+      'foo' => 'bar',
+    ], $this->paramsFactory->createParams($actionDefinition));
+  }
+
+  public function testWithExpression(): void {
+    $actionDefinition = (object) [
+      'entity' => 'SomeEntity',
+      'action' => 'get',
+      'result_map' => (object) [
+        'btx.some_value' => 'baz',
+        'btx.another_value' => "@=result.first()['test']",
+      ],
+    ];
+
+    static::assertEquals([
+      // 'limit' is not set with expression.
+      // 'select' has to be empty.
+      'select' => [],
+    ], $this->paramsFactory->createParams($actionDefinition));
+  }
+
+  public function testUseAllResults(): void {
+    $actionDefinition = (object) [
+      'entity' => 'SomeEntity',
+      'action' => 'get',
+      'result_map' => (object) [
+        'btx.some_value' => 'baz',
+      ],
+      'result_map_options' => (object) [
+        'use_all_results' => TRUE,
+      ],
+    ];
+
+    // 'limit' is not set.
+    static::assertEquals([
+      'select' => ['baz'],
+    ], $this->paramsFactory->createParams($actionDefinition));
+  }
+
+  public function testIndexBy(): void {
+    $actionDefinition = (object) [
+      'entity' => 'SomeEntity',
+      'action' => 'get',
+      'result_map' => (object) [
+        'btx.some_value' => 'baz',
+      ],
+      'result_map_options' => (object) [
+        'use_all_results' => TRUE,
+        'index_by' => 'bar',
+      ],
+    ];
+
+    // index_by field is in 'select'.
+    static::assertEquals([
+      'select' => ['bar', 'baz'],
+    ], $this->paramsFactory->createParams($actionDefinition));
+  }
+
+}

--- a/tests/phpunit/Civi/Banking/Matcher/Helper/Api4ResultMapperTest.php
+++ b/tests/phpunit/Civi/Banking/Matcher/Helper/Api4ResultMapperTest.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\Helper;
+
+use Civi\Api4\Generic\Result;
+use Civi\Banking\ExpressionLanguage\BankingExpressionLanguage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Banking\Matcher\Helper\Api4ResultMapper
+ */
+final class Api4ResultMapperTest extends TestCase {
+
+  private Api4ResultMapper $resultMapper;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->resultMapper = new Api4ResultMapper(new BankingExpressionLanguage());
+  }
+
+  public function testSimple(): void {
+    $result = new Result([['foo' => 'bar']]);
+    $resultMap = ['btx.field' => 'foo'];
+    $options = new Api4ResultMapOptions();
+
+    static::assertSame(
+      ['btx.field' => 'bar'],
+      [...$this->resultMapper->applyResultMap($result, $resultMap, $options)]
+    );
+  }
+
+  public function testSkipEmptyResult(): void {
+    $result = new Result([]);
+    $resultMap = ['btx.field' => 'foo'];
+    $options = new Api4ResultMapOptions();
+
+    static::assertSame(
+      [],
+      [...$this->resultMapper->applyResultMap($result, $resultMap, $options)]
+    );
+  }
+
+  public function testDontSkipEmptyResult(): void {
+    $result = new Result([]);
+    $resultMap = ['btx.field' => 'foo'];
+    $options = new Api4ResultMapOptions(skipEmptyResult: FALSE);
+
+    static::assertSame(
+      ['btx.field' => NULL],
+      [...$this->resultMapper->applyResultMap($result, $resultMap, $options)]
+    );
+  }
+
+  public function testUseAllResults(): void {
+    $result = new Result([['foo' => 'bar1'], ['foo' => 'bar2']]);
+    $resultMap = ['btx.field' => 'foo'];
+    $options = new Api4ResultMapOptions(useAllResults: TRUE);
+
+    static::assertSame(
+      ['btx.field' => ['bar1', 'bar2']],
+      [...$this->resultMapper->applyResultMap($result, $resultMap, $options)]
+    );
+  }
+
+  public function testIndexBy(): void {
+    $result = new Result([['id' => 12, 'foo' => 'bar1'], ['id' => 34, 'foo' => 'bar2']]);
+    $resultMap = ['btx.field' => 'foo'];
+    $options = new Api4ResultMapOptions(useAllResults: TRUE, indexBy: 'id');
+
+    static::assertSame(
+      ['btx.field' => [12 => 'bar1', 34 => 'bar2']],
+      [...$this->resultMapper->applyResultMap($result, $resultMap, $options)]
+    );
+  }
+
+  public function testExpression(): void {
+    $result = new Result([['foo' => 'bar']]);
+    $resultMap = ['btx.field' => "@=result.single()['foo'] ~ '_test'"];
+    $options = new Api4ResultMapOptions();
+
+    static::assertSame(
+      ['btx.field' => 'bar_test'],
+      [...$this->resultMapper->applyResultMap($result, $resultMap, $options)]
+    );
+  }
+
+}

--- a/tests/phpunit/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandlerTest.php
+++ b/tests/phpunit/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandlerTest.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\RegexAnalyser\ActionHandlers;
+
+use Civi\Api4\Generic\Result;
+use Civi\Banking\Matcher\Helper\Api4ParamsFactory;
+use Civi\Banking\Matcher\Helper\Api4ResultMapper;
+use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * @covers \Civi\Banking\Matcher\RegexAnalyser\ActionHandlers\Api4RegexAnalyserActionHandler
+ */
+final class Api4RegexAnalyserActionHandlerTest extends TestCase {
+
+  private MockObject $api4Mock;
+
+  private Api4RegexAnalyserActionHandler $handler;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->api4Mock = $this->createPartialMock(\stdClass::class, ['execute']);
+    $expressionLanguage = new ExpressionLanguage();
+    $this->handler = new Api4RegexAnalyserActionHandler(
+      new Api4ParamsFactory($expressionLanguage),
+      new Api4ResultMapper($expressionLanguage),
+      // @phpstan-ignore method.notFound
+      fn (...$args) => $this->api4Mock->execute(...$args),
+    );
+  }
+
+  public function testExecuteNoResult(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', 'bar'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'baz',
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+
+    $this->api4Mock->expects(static::once())
+      ->method('execute')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 'bar']],
+        'select' => ['baz'],
+      ])
+      ->willReturn(new Result([]));
+
+    $contextMock->expects(static::never())->method('setValue');
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteSingleResult(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', '@=foo + btx.foo'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'bar',
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+    $contextMock->method('getMatchedValues')->willReturn(['foo' => '2']);
+    $contextMock->method('getValue')->with('btx.foo')->willReturn(3);
+
+    $this->api4Mock->expects(static::once())
+      ->method('execute')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 5]],
+        'select' => ['bar'],
+      ])
+      ->willReturn(new Result([['bar' => 'test1'], ['bar' => 'test2']]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', 'test1,test2');
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteMultipleResults(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', "@=foo + party_ba['foo.foo']"],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'bar',
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+    $contextMock->method('getMatchedValues')->willReturn(['foo' => '2']);
+    $contextMock->method('getValue')->with('party_ba.foo.foo')->willReturn(3);
+
+    $this->api4Mock->expects(static::once())
+      ->method('execute')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 5]],
+        'select' => ['bar'],
+      ])
+      ->willReturn(new Result([
+        ['bar' => 'test1'],
+        ['bar' => 'test2'],
+      ]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', 'test1,test2');
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteExpression(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', '@=foo + btx.foo'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => "@=result.first()['bar'][0] ~ result.first()['baz']",
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+    $contextMock->method('getMatchedValues')->willReturn(['foo' => '2']);
+    $contextMock->method('getValue')->with('btx.foo')->willReturn(3);
+
+    $this->api4Mock->expects(static::once())
+      ->method('execute')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 5]],
+        'select' => [],
+      ])
+      ->willReturn(new Result([['bar' => ['test1', 234], 'baz' => 'test2']]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', 'test1test2');
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+}

--- a/tests/phpunit/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandlerTest.php
+++ b/tests/phpunit/Civi/Banking/Matcher/RegexAnalyser/ActionHandlers/Api4RegexAnalyserActionHandlerTest.php
@@ -1,0 +1,243 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\Banking\Matcher\RegexAnalyser\ActionHandlers;
+
+use Civi\Api4\Generic\Result;
+use Civi\Banking\Api4Mock;
+use Civi\Banking\ExpressionLanguage\BankingExpressionLanguage;
+use Civi\Banking\Matcher\Helper\Api4ParamsFactory;
+use Civi\Banking\Matcher\Helper\Api4ResultMapper;
+use Civi\Banking\Matcher\RegexAnalyser\RegexAnalyserMatchContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Banking\Matcher\RegexAnalyser\ActionHandlers\Api4RegexAnalyserActionHandler
+ */
+final class Api4RegexAnalyserActionHandlerTest extends TestCase {
+
+  private Api4Mock&MockObject $api4Mock;
+
+  private Api4RegexAnalyserActionHandler $handler;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->api4Mock = $this->createMock(Api4Mock::class);
+    $expressionLanguage = new BankingExpressionLanguage();
+    $this->handler = new Api4RegexAnalyserActionHandler(
+      new Api4ParamsFactory($expressionLanguage),
+      new Api4ResultMapper($expressionLanguage),
+      $this->api4Mock
+    );
+  }
+
+  public function testExecuteNoResult(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', 'bar'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'baz',
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+
+    $this->api4Mock->expects(static::once())
+      ->method('__invoke')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 'bar']],
+        'select' => ['baz'],
+        'limit' => 1,
+      ])
+      ->willReturn(new Result([]));
+
+    $contextMock->expects(static::never())->method('setValue');
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteDontSkipEmptyResult(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', 'bar'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'baz',
+        ],
+        'result_map_options' => (object) [
+          'skip_empty_result' => FALSE,
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+
+    $this->api4Mock->expects(static::once())
+      ->method('__invoke')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 'bar']],
+        'select' => ['baz'],
+        'limit' => 1,
+      ])
+      ->willReturn(new Result([]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', NULL);
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteSingleResult(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', '@=foo + btx.foo'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'bar',
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+    $contextMock->method('getMatchedValues')->willReturn(['foo' => '2']);
+    $contextMock->method('getValue')->with('btx.foo')->willReturn(3);
+
+    $this->api4Mock->expects(static::once())
+      ->method('__invoke')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 5]],
+        'select' => ['bar'],
+        'limit' => 1,
+      ])
+      ->willReturn(new Result([['bar' => 123]]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', 123);
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteMultipleResults(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', "@=foo + party_ba['foo.foo']"],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => 'bar',
+        ],
+        'result_map_options' => (object) [
+          'use_all_results' => TRUE,
+          'index_by' => 'id',
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+    $contextMock->method('getMatchedValues')->willReturn(['foo' => '2']);
+    $contextMock->method('getValue')->with('party_ba.foo.foo')->willReturn(3);
+
+    $this->api4Mock->expects(static::once())
+      ->method('__invoke')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 5]],
+        'select' => ['id', 'bar'],
+      ])
+      ->willReturn(new Result([
+        ['id' => 12, 'bar' => 'test1'],
+        ['id' => 34, 'bar' => 'test2'],
+      ]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', [12 => 'test1', 34 => 'test2']);
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+  public function testExecuteExpression(): void {
+    $action = (object) [
+      'action' => 'api4',
+      'api4' => (object) [
+        'entity' => 'SomeEntity',
+        'action' => 'get',
+        'params' => (object) [
+          'where' => [
+            ['foo', '=', '@=foo + btx.foo'],
+          ],
+        ],
+        'result_map' => (object) [
+          'btx.some_value' => "@=result.first()['bar'][0] ~ result.first()['baz']",
+        ],
+      ],
+    ];
+
+    $contextMock = $this->createMock(RegexAnalyserMatchContext::class);
+    $contextMock->method('getMatchedValues')->willReturn(['foo' => '2']);
+    $contextMock->method('getValue')->with('btx.foo')->willReturn(3);
+
+    $this->api4Mock->expects(static::once())
+      ->method('__invoke')
+      ->with('SomeEntity', 'get', [
+        'where' => [['foo', '=', 5]],
+        'select' => [],
+      ])
+      ->willReturn(new Result([['bar' => ['test1', 234], 'baz' => 'test2']]));
+
+    $contextMock
+      ->expects(static::once())
+      ->method('setValue')
+      ->with('btx.some_value', 'test1test2');
+
+    $this->handler->execute($action, $contextMock);
+  }
+
+}


### PR DESCRIPTION
This adds an regex analyser action handler for the action "api4" to execute APIv4 actions. It is inspired by https://github.com/Project60/org.project60.banking/pull/513.

To use values from the pattern matches, the bank transaction (`btx`), the bank account (`ba`), or the party bank account (`party_ba`) the [Symfony Expression Language](https://symfony.com/doc/current/components/expression_language.html) is used. So it is not only possible to access a single value, but to do some mathematics and other things. Strings starting with `@=` (this is the prefix Symfony uses in config files) are interpreted as expressions. I decided to give expressions also a try in the `result_map` in addition to what was discussed in #513. In expressions in the result map the `Result` object is available as variable `result`. I'm not sure if we need and want to have two approaches. (This is something to be discussed.) With the expression language the expression `@=result.first()['some_field'][0] ?? NULL` could be used instead of the `first` filter.

The Symfony Expression Language can be [extended](https://symfony.com/doc/current/components/expression_language.html#extending-the-expressionlanguage) with custom functions so we're not limited to the ones available by default. (We could even consider giving third party extensions the possibility to provide custom functions.)

Adapted example from #513:

```json
{
  "comment": "Look for previous contribution with matching bank name and amount",
  "action": "api4",
  "api4": {
    "entity": "Contribution",
    "action": "get",
    "params": {
      "limit": 1,
      "orderBy": {
        "receive_date": "DESC"
      },
      "where": [
        [
          "Donor_Information.Bank_Name",
          "=",
          "@=purpose"
        ],
        [
          "total_amount",
          "=",
          "@=btx.amount"
        ]
      ]
    },
    "result_map": {
      "previous_contribution_id": "id",
      "contact_id": "contact_id"
      "financial_type_id": "@=result.first()['financial_type_id']",
    }
  }
},
```

Actually `@=result.first()['financial_type_id']` is the same as just `financial_type_id` here with results limited to one in the API call. It's just meant as an example. In `\Civi\Banking\Matcher\RegexAnalyser\ActionHandlers\Api4RegexAnalyserActionHandlerTest` you can find expressions with operations (addition, string concatenation).

Note: The `.` is the object access operator in expressions which prevents using dots in pattern matches. In case there are values with `.` in the parsed data of `btx`, array access can be used: `btx['foo.bar']`.

I'd like to hear your opinions @ufundo, @jensschuppe.

Another thing I'm currently unsure about: What is the expected behavior when the APIv4 call returns no result, but a result map is defined. The current implementation doesn't set any value at all, though another option would be to set `NULL`. In case of expressions they might be evaluated with the empty result object.

*systopia-reference: ~~30273~~ 32247*