### PR TITLE
api3 deletelist queries expect strings

### DIFF
--- a/templates/CRM/Banking/Page/Payments.tpl
+++ b/templates/CRM/Banking/Page/Payments.tpl
@@ -340,7 +340,8 @@ function deleteSelected() {
     // call the API to delete the items
     var query = {'q': 'civicrm/ajax/rest', 'sequential': 1};
     // set the list or s_list parameter depending on the page mode
-    query['{/literal}{if $show eq 'statements'}s_list{else}list{/if}{literal}'] = selected_string;
+    // NOTE: api3 expects the param as a string
+    query['{/literal}{if $show eq 'statements'}s_list{else}list{/if}{literal}'] = `${selected_string}`;
     CRM.api('BankingTransaction', 'deletelist', query,
       {success: function(data) {
           if (!data['is_error']) {

--- a/templates/CRM/Banking/Page/StatementLine.tpl
+++ b/templates/CRM/Banking/Page/StatementLine.tpl
@@ -6,7 +6,7 @@
     <h3>{ts domain='org.project60.banking'}Filter lines{/ts}</h3>
     <table class="form-layout">
       <tbody>
-      <tr>        
+      <tr>
         <td>
         <strong>{ts domain='org.project60.banking'}Status{/ts}</strong>&nbsp;
         {foreach from=$statuses item=status key=status_id}
@@ -16,7 +16,7 @@
         </td>
       </tr>
     </table>
-    
+
     <div class="crm-submit-buttons">
     <input type="submit" class="crm-form-submit" value="{ts escape='htmlattribute' domain='org.project60.banking'}Filter{/ts}">
     </div>
@@ -187,7 +187,8 @@ function deleteLine(line_id) {
     // call the API to delete the items
     var query = {'q': 'civicrm/ajax/rest', 'sequential': 1};
     // set the list or s_list parameter depending on the page mode
-    query['list'] = line_id;
+    // NOTE: api3 expects the param as a string
+    query['list'] = `${line_id}`;
     CRM.api('BankingTransaction', 'deletelist', query,
       {success: function(data) {
           if (!data['is_error']) {

--- a/templates/CRM/Banking/Page/Statements.tpl
+++ b/templates/CRM/Banking/Page/Statements.tpl
@@ -259,7 +259,8 @@ function deleteStatement(statement_id) {
     // call the API to delete the items
     var query = {'q': 'civicrm/ajax/rest', 'sequential': 1};
     // set the list or s_list parameter depending on the page mode
-    query['s_list'] = statement_id;
+    // NOTE: api3 expects the param as a string
+    query['s_list'] = `${statement_id}`;
     CRM.api('BankingTransaction', 'deletelist', query,
       {success: function(data) {
           if (!data['is_error']) {


### PR DESCRIPTION
This fixes a bug on Drupal 10, CiviCRM 6.12, PHP8.3 where the parameter comes through to the server as an integer, and then is passed to `explode` on the serverside, which crashes.

This is probably not the best fix, but it was an easy fix.