### PR TITLE
fixes #532: `explode(): Argument #2 ($string) must be of type string, int given

### DIFF
--- a/CRM/Banking/PluginModel/BtxBase.php
+++ b/CRM/Banking/PluginModel/BtxBase.php
@@ -59,7 +59,7 @@ abstract class CRM_Banking_PluginModel_BtxBase extends CRM_Banking_PluginModel_B
       foreach ($required_values as $required_key => $required_value) {
         $this->logMessage("Evaluating {$required_key}: {$required_value}", 'debug');
         $current_value = $this->getPropagationValue($btx, NULL, $required_key);
-        $split = explode(':', $required_value, 2);
+        $split = explode(':', (string) $required_value, 2);
         if (count($split) < 2) {
           error_log("org.project60.banking: required_value in config option not properly formatted, plugin id [{$this->_plugin_id}]");
         }


### PR DESCRIPTION
We have a matcher plugin with the following configuration:

```
{
  ...
  "required_values": [
    "btx.financial_type_id",
    "btx.campaign_id",
    "ogm_is_valid:not_in_constant:1"
  ],
...
```

When we try to analyse a transaction we get an error `explode(): Argument #2 ($string) must be of type string, int given`  in org.project60.banking/CRM/Banking/PluginModel/BtxBase.php:62

Whlist we expect that analyzing to finish. 

This error is on php version 8.3. The fix is quite straight foward and easy to implement.