### PR TITLE
Add type cast to call of `CRM_Utils_SepaOptionGroupTools::getFrequencyText()`

### DIFF
--- a/CRM/Banking/PluginImpl/Matcher/SepaMandate.php
+++ b/CRM/Banking/PluginImpl/Matcher/SepaMandate.php
@@ -646,6 +646,7 @@ class CRM_Banking_PluginImpl_Matcher_SepaMandate extends CRM_Banking_PluginModel
       $mandate = civicrm_api3('SepaMandate', 'getsingle', ['id' => $mandate_id]);
       if ($mandate['type'] == 'RCUR' && $mandate['entity_table'] == 'civicrm_contribution_recur') {
         // add some additional parameters for RCUR (see #256)
+        /** @var array{frequency_interval: numeric-string, frequency_unit: string, ...} $rcur */
         $rcur = civicrm_api3('ContributionRecur', 'getsingle', ['id' => $mandate['entity_id']]);
         foreach ($rcur as $key => $value) {
           $mandate["rcur_{$key}"] = $value;
@@ -653,7 +654,7 @@ class CRM_Banking_PluginImpl_Matcher_SepaMandate extends CRM_Banking_PluginModel
 
         // if CiviSEPA is present, add a nicer
         if (method_exists('CRM_Utils_SepaOptionGroupTools', 'getFrequencyText')) {
-          $mandate['rcur_frequency'] = CRM_Utils_SepaOptionGroupTools::getFrequencyText($rcur['frequency_interval'], $rcur['frequency_unit'], TRUE);
+          $mandate['rcur_frequency'] = CRM_Utils_SepaOptionGroupTools::getFrequencyText((int) $rcur['frequency_interval'], $rcur['frequency_unit'], TRUE);
         }
         else {
           if ($rcur['frequency_interval'] == 1) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7409,12 +7409,6 @@ parameters:
 			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
 
 		-
-			message: '#^Argument of an invalid type array\|int supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
-
-		-
 			message: '#^Call to an undefined method object\:\:fetch\(\)\.$#'
 			identifier: method.notFound
 			count: 3
@@ -7460,18 +7454,6 @@ parameters:
 			message: '#^Cannot access offset ''error_message'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
-
-		-
-			message: '#^Cannot access offset ''frequency_interval'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
-
-		-
-			message: '#^Cannot access offset ''frequency_unit'' on array\|int\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
 			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
 
 		-
@@ -7525,6 +7507,12 @@ parameters:
 		-
 			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
 			identifier: catch.neverThrown
+			count: 1
+			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
+
+		-
+			message: '#^Equal\: Condition between 1 and numeric\-string are falsy, please do not mix types\.$#'
+			identifier: voku.Equal
 			count: 1
 			path: CRM/Banking/PluginImpl/Matcher/SepaMandate.php
 


### PR DESCRIPTION
`CRM_Utils_SepaOptionGroupTools::getFrequencyText()` requires an int, not an integerish string.