### PR TITLE
Fixes #538: smarty error: undefined modifier @key

### DIFF
--- a/CRM/Banking/PluginImpl/Matcher/RecurringContribution.php
+++ b/CRM/Banking/PluginImpl/Matcher/RecurringContribution.php
@@ -378,6 +378,7 @@ class CRM_Banking_PluginImpl_Matcher_RecurringContribution extends CRM_Banking_P
     // assign to smarty and compile HTML
     $smarty_vars['recurring_contributions'] = $rcontributions;
     $smarty_vars['contacts']                = $contacts;
+    $smarty_vars['contact_id']              = array_key_first($contacts);
     $smarty_vars['penalties']               = $match->getEvidence();
 
     $smarty = CRM_Banking_Helpers_Smarty::singleton();

--- a/templates/CRM/Banking/PluginImpl/Matcher/RecurringContribution.suggestion.tpl
+++ b/templates/CRM/Banking/PluginImpl/Matcher/RecurringContribution.suggestion.tpl
@@ -16,7 +16,6 @@
 <div>
   <p>
   {if $recurring_contributions|@count eq 1}
-    {assign var=contact_id value=$contacts|@key}
     {assign var=contact value=$contacts.$contact_id}
     {capture assign=address_text}{if $contact.city}{$contact.street_address}, {$contact.city}{else}{ts domain='org.project60.banking'}Address incomplete{/ts}{/if}{/capture}
     {capture assign=contact_link}<a title="{$address_text}" href="{crmURL p="civicrm/contact/view" q="reset=1&cid=$contact_id"}">{$contact.display_name} [{$contact.id}]</a>{/capture}
@@ -27,7 +26,6 @@
   {else}
     {assign var=recurring_contribution_count value=$recurring_contributions|@count}
     {if $contacts|@count eq 1}
-      {assign var=contact_id value=$contacts|@key}
       {assign var=contact value=$contacts.$contact_id}
       {capture assign=address_text}{if $contact.city}{$contact.street_address}, {$contact.city}{else}{ts domain='org.project60.banking'}Address incomplete{/ts}{/if}{/capture}
       {capture assign=contact_link}<a title="{$address_text}" href="{crmURL p="civicrm/contact/view" q="reset=1&cid=$contact_id"}">{$contact.display_name} [{$contact.id}]</a>{/capture}


### PR DESCRIPTION
When a matcher for contribution recur is shown smarty returns a fatal error.

<img width="1509" height="152" alt="2026-05-26_15-37" src="https://github.com/user-attachments/assets/d410f79e-b341-4c94-ad99-dafd42aba0f8" />


This PR fixes that error. By passing the first found contact id to smarty as a variable.

This fixes #538 