### PR TITLE
Replace deprecated CRM_Core_BAO_Setting::getItem with Civi::settings()

### DIFF
--- a/CRM/Admin/Form/Setting/BankingSettings.php
+++ b/CRM/Admin/Form/Setting/BankingSettings.php
@@ -210,10 +210,10 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     $values = $this->exportValues();
 
     // process menu relevant entries
-    $old_menu_position = (int) CRM_Core_BAO_Setting::getItem('CiviBanking', 'menu_position');
+    $old_menu_position = (int) Civi::settings()->get('menu_position');
     $new_menu_position = (int) $values['menu_position'];
 
-    $old_ui_style = (int) CRM_Core_BAO_Setting::getItem('CiviBanking', 'new_ui');
+    $old_ui_style = (int) Civi::settings()->get('new_ui');
     $new_ui_style = (int) $values['new_ui'];
 
     if ($old_menu_position != $new_menu_position || $old_ui_style != $new_ui_style) {

--- a/CRM/Banking/BAO/BankAccount.php
+++ b/CRM/Banking/BAO/BankAccount.php
@@ -91,7 +91,7 @@ class CRM_Banking_BAO_BankAccount extends CRM_Banking_DAO_BankAccount {
    *   ordered by the reference types' order in the option group
    */
   public function getReferences() {
-    $bank_account_reference_matching_probability = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_matching_probability');
+    $bank_account_reference_matching_probability = Civi::settings()->get('reference_matching_probability');
     if ($bank_account_reference_matching_probability === NULL) {
       $bank_account_reference_matching_probability = 1.0;
     }

--- a/CRM/Banking/Config.php
+++ b/CRM/Banking/Config.php
@@ -38,7 +38,7 @@ class CRM_Banking_Config {
    * @return boolean
    */
   public static function lenientDedupe() {
-    $value = CRM_Core_BAO_Setting::getItem('CiviBanking', 'lenient_dedupe');
+    $value = Civi::settings()->get('lenient_dedupe');
     if (empty($value)) {
       return FALSE;
     }

--- a/CRM/Banking/Form/AccountsTab.php
+++ b/CRM/Banking/Form/AccountsTab.php
@@ -84,8 +84,8 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
     }
 
     // load settings
-    $this->assign('reference_normalisation', (int) CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_normalisation'));
-    $this->assign('reference_validation', (int) CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_validation'));
+    $this->assign('reference_normalisation', (int) Civi::settings()->get('reference_normalisation'));
+    $this->assign('reference_validation', (int) Civi::settings()->get('reference_validation'));
 
     // ACCOUNT REFRENCE ITEMS
     $this->add('hidden', 'contact_id', $contact_id);
@@ -100,7 +100,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
         TRUE
     );
     // set last value
-    $reference_type->setSelected(CRM_Core_BAO_Setting::getItem('CiviBanking', 'account.default_reference_id'));
+    $reference_type->setSelected(Civi::settings()->get('account.default_reference_id'));
 
     $reference_type = $this->add(
         'text',
@@ -137,7 +137,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
         FALSE
     );
     // set last value
-    $country->setSelected(CRM_Core_BAO_Setting::getItem('CiviBanking', 'account.default_country'));
+    $country->setSelected(Civi::settings()->get('account.default_country'));
 
     $this->addButtons([
       [
@@ -161,8 +161,8 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
   public function validate() {
     $error = parent::validate();
     $values = $this->exportValues();
-    $normalise = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_normalisation');
-    $validate  = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_validation');
+    $normalise = Civi::settings()->get('reference_normalisation');
+    $validate  = Civi::settings()->get('reference_validation');
 
     if (!empty($values['reference_type']) && !empty($values['reference'])) {
       if ($validate || $normalise) {

--- a/CRM/Banking/Form/Configure.php
+++ b/CRM/Banking/Form/Configure.php
@@ -46,7 +46,7 @@ class CRM_Banking_Form_Configure extends CRM_Core_Form {
     }
 
     // set default editor mode
-    $json_editor_mode = CRM_Core_BAO_Setting::getItem('CiviBanking', 'json_editor_mode');
+    $json_editor_mode = Civi::settings()->get('json_editor_mode');
     if (empty($json_editor_mode)) {
       $json_editor_mode = 'text';
     }

--- a/CRM/Banking/Helpers/Logger.php
+++ b/CRM/Banking/Helpers/Logger.php
@@ -52,7 +52,7 @@ class CRM_Banking_Helpers_Logger {
   protected function __construct() {
     // read log level
     $all_levels = self::getLoglevels();
-    $this->log_level = CRM_Core_BAO_Setting::getItem('CiviBanking', 'banking_log_level');
+    $this->log_level = Civi::settings()->get('banking_log_level');
     if (!isset($all_levels[$this->log_level])) {
       // invalid log level -> fall back to 'off'
       $this->log_level = 'off';
@@ -62,7 +62,7 @@ class CRM_Banking_Helpers_Logger {
     $this->timers = [];
 
     // create log file
-    $log_file = CRM_Core_BAO_Setting::getItem('CiviBanking', 'banking_log_file');
+    $log_file = Civi::settings()->get('banking_log_file');
     if (!empty($log_file)) {
       // log to file:
       if (substr($log_file, 0, 1) != '/') {

--- a/CRM/Banking/Matcher/Context.php
+++ b/CRM/Banking/Matcher/Context.php
@@ -38,7 +38,7 @@ class CRM_Banking_Matcher_Context {
     $this->btx = $btx;
     $btx->context = $this;
 
-    $this->bank_account_reference_matching_probability = CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_matching_probability');
+    $this->bank_account_reference_matching_probability = Civi::settings()->get('reference_matching_probability');
     if ($this->bank_account_reference_matching_probability === NULL) {
       $this->bank_account_reference_matching_probability = 1.0;
     }

--- a/CRM/Banking/Page/Import.php
+++ b/CRM/Banking/Page/Import.php
@@ -132,7 +132,7 @@ class CRM_Banking_Page_Import extends CRM_Core_Page {
     }
 
     // URLs
-    $new_ui_enabled = CRM_Core_BAO_Setting::getItem('CiviBanking', 'new_ui');
+    $new_ui_enabled = Civi::settings()->get('new_ui');
     if ($new_ui_enabled) {
       $this->assign('url_payments', CRM_Utils_System::url('civicrm/banking/statements'));
     }

--- a/CRM/Banking/Page/Review.php
+++ b/CRM/Banking/Page/Review.php
@@ -30,7 +30,7 @@ class CRM_Banking_Page_Review extends CRM_Core_Page {
   // phpcs:enable
     CRM_Core_Resources::singleton()->addStyleFile(E::LONG_NAME, 'css/banking.css');
 
-    $new_ui_enabled = CRM_Core_BAO_Setting::getItem('CiviBanking', 'new_ui');
+    $new_ui_enabled = Civi::settings()->get('new_ui');
     // set this variable to request a redirect
     $url_redirect = NULL;
 
@@ -330,7 +330,7 @@ class CRM_Banking_Page_Review extends CRM_Core_Page {
     $popups_allowed = (int) version_compare(CRM_Utils_System::version(), '4.6', '>=');
     // take the popup switch into account (thanks @VangelisP)
     if ($popups_allowed) {
-      $popups_allowed = (int) CRM_Core_BAO_Setting::getItem('CiviCRM Preferences', 'ajaxPopupsEnabled');
+      $popups_allowed = (int) Civi::settings()->get('ajaxPopupsEnabled');
     }
     $this->assign('popups_allowed', $popups_allowed);
 

--- a/CRM/Banking/PluginModel/Matcher.php
+++ b/CRM/Banking/PluginModel/Matcher.php
@@ -261,7 +261,7 @@ abstract class CRM_Banking_PluginModel_Matcher extends CRM_Banking_PluginModel_B
   public function storeAccountWithContact($btx, $contact_id) {
   // phpcs:enable
     // check if this has been turned off
-    if (CRM_Core_BAO_Setting::getItem('CiviBanking', 'reference_store_disabled')) {
+    if (Civi::settings()->get('reference_store_disabled')) {
       return;
     }
 

--- a/banking.php
+++ b/banking.php
@@ -218,7 +218,7 @@ function banking_civicrm_entityTypes(&$entityTypes) {
  */
 function banking_civicrm_navigationMenu(&$menu) {
   // check if we want the menu to be built at all
-  $menu_position = (int) CRM_Core_BAO_Setting::getItem('CiviBanking', 'menu_position');
+  $menu_position = (int) Civi::settings()->get('menu_position');
   switch ($menu_position) {
     case 2:
       // menu is off, see CRM_Admin_Form_Setting_BankingSettings
@@ -241,7 +241,7 @@ function banking_civicrm_navigationMenu(&$menu) {
 
   // Determine the url for the statements/payments (new ui or old ui).
   $statementUrl = 'civicrm/banking/statements';
-  if (!CRM_Core_BAO_Setting::getItem('CiviBanking', 'new_ui')) {
+  if (!Civi::settings()->get('new_ui')) {
     $statementUrl = 'civicrm/banking/payments';
   }
 


### PR DESCRIPTION
Replaces calls to the older `CRM_Core_BAO_Setting::getItem` with the recommended alternative `Civi::settings()`.