### PR TITLE
Keep suggestions sorted by probability so auto-execution picks the best one

### DIFF
--- a/CRM/Banking/BAO/BankTransaction.php
+++ b/CRM/Banking/BAO/BankTransaction.php
@@ -116,7 +116,11 @@ class CRM_Banking_BAO_BankTransaction extends CRM_Banking_DAO_BankTransaction {
    * @todo after a load/retrieve, need to convert the suggestions/data_parsed from JSON to array
    */
   public function getSuggestions() {
-    return $this->suggestion_objects;
+    // Auto-execution runs the first suggestion above its threshold,
+    // so the most probable ones have to come first.
+    $suggestions = $this->suggestion_objects;
+    krsort($suggestions);
+    return $suggestions;
   }
 
   /**
@@ -174,8 +178,7 @@ class CRM_Banking_BAO_BankTransaction extends CRM_Banking_DAO_BankTransaction {
    */
   public function getSuggestionList() {
     $suggestions = [];
-    krsort($this->suggestion_objects);
-    foreach ($this->suggestion_objects as $probability => $list) {
+    foreach ($this->getSuggestions() as $probability => $list) {
       foreach ($list as $item) {
         array_push($suggestions, $item);
       }
@@ -212,8 +215,7 @@ class CRM_Banking_BAO_BankTransaction extends CRM_Banking_DAO_BankTransaction {
    */
   public function saveSuggestions() {
     $sugs = [];
-    krsort($this->suggestion_objects);
-    foreach ($this->suggestion_objects as $probability => $list) {
+    foreach ($this->getSuggestions() as $probability => $list) {
       foreach ($list as $sug) {
         $sugs[] = $sug->prepForJson();
       }

--- a/tests/phpunit/CRM/Banking/BAO/BankTransactionTest.php
+++ b/tests/phpunit/CRM/Banking/BAO/BankTransactionTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Test the bank transaction BAO
+ *
+ * @covers CRM_Banking_BAO_BankTransaction
+ *
+ * @group headless
+ */
+class CRM_Banking_BAO_BankTransactionTest extends CRM_Banking_TestBase {
+
+  /**
+   * Suggestions must be iterable from the most to the least probable no
+   * matter in which order they were added — the matcher engine relies on
+   * this when it auto-executes the first qualifying suggestion.
+   */
+  public function testSuggestionsAreOrderedByProbability(): void {
+    $matcher_id = $this->createMatcher('match', 'matcher_contribution');
+    $plugin = $this->getPluginInstance($matcher_id);
+    static::assertInstanceOf(CRM_Banking_PluginModel_Matcher::class, $plugin);
+    $transaction = $this->getTransactionInstance($this->createTransaction());
+    static::assertInstanceOf(CRM_Banking_BAO_BankTransaction::class, $transaction);
+
+    foreach ([0.5, 0.95, 0.7] as $probability) {
+      $suggestion = new CRM_Banking_Matcher_Suggestion($plugin, $transaction);
+      $suggestion->setProbability($probability);
+      $suggestion->setId("test-{$probability}");
+      $transaction->addSuggestion($suggestion);
+    }
+
+    $seen = [];
+    foreach ($transaction->getSuggestions() as $suggestions) {
+      foreach ($suggestions as $suggestion) {
+        $seen[] = $suggestion->getProbability();
+      }
+    }
+    static::assertSame([0.95, 0.7, 0.5], $seen, 'Suggestions are not iterated from the most probable one.');
+  }
+
+}

--- a/tests/phpunit/CRM/Banking/Matcher/MatchContributionTest.php
+++ b/tests/phpunit/CRM/Banking/Matcher/MatchContributionTest.php
@@ -60,4 +60,55 @@ class CRM_Banking_Matcher_MatchContributionMatcherTest extends CRM_Banking_TestB
     $this->assertEquals(1, $completed_contribution['contribution_status_id'], "Contribution wasn't completed.");
   }
 
+  /**
+   * With several candidates above the auto-exec threshold, the most probable
+   * one must be executed — not the one the database happened to return first.
+   */
+  public function testAutoExecutionPicksMostProbableSuggestion(): void {
+    $contact_id = $this->createContact();
+    $financial_type_id = $this->getRandomFinancialTypeID();
+    $payment_instrument_id = $this->getRandomOptionValue('payment_instrument');
+    $shared = [
+      'contact_id'             => $contact_id,
+      'contribution_status_id' => 'Pending',
+      'total_amount'           => 42.0,
+      'financial_type_id'      => $financial_type_id,
+      'payment_instrument_id'  => $payment_instrument_id,
+    ];
+    // The older contribution is created first, i.e. gets the lower id and is
+    // returned first by the candidate query; the date penalty leaves it at ~0.9.
+    $older_contribution = $this->createContribution($shared + ['receive_date' => date('Y-m-d', strtotime('-30 days'))]);
+    $recent_contribution = $this->createContribution($shared + ['receive_date' => date('Y-m-d')]);
+
+    $this->createTransaction([
+      'purpose'      => 'Late-then-on-time donor',
+      'name'         => "doesn't matter",
+      'amount'       => 42.0,
+      'contact_id'   => $contact_id,
+      'booking_date' => date('Y-m-d'),
+      'value_date'   => date('Y-m-d'),
+      'currency'     => $recent_contribution['currency'],
+    ]);
+    $this->configureCiviBankingModule(
+      $this->getTestResourcePath('matcher/configuration/ExistingContribution-02.civibanking'));
+
+    $this->runMatchers();
+
+    // get() restores the stored suggestions, find()/fetch() would not.
+    $transaction = new CRM_Banking_BAO_BankTransaction();
+    $transaction->get('id', (string) $this->getLatestTransactionId());
+    static::assertEquals($this->getTxStatusID('processed'), $transaction->status_id, 'Transaction was not processed automatically.');
+    $probabilities = [];
+    foreach ($transaction->getSuggestionList() as $suggestion) {
+      $probabilities[$suggestion->getParameter('contribution_id')] = $suggestion->getProbability();
+    }
+    static::assertCount(2, $probabilities, 'Both pending contributions should have been suggested.');
+    static::assertGreaterThan($probabilities[$older_contribution['id']], $probabilities[$recent_contribution['id']]);
+
+    $recent = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $recent_contribution['id']]);
+    $older = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $older_contribution['id']]);
+    static::assertEquals(1, $recent['contribution_status_id'], 'The most probable contribution was not completed.');
+    static::assertEquals(2, $older['contribution_status_id'], 'The less probable contribution was reconciled instead.');
+  }
+
 }

--- a/tests/resources/matcher/configuration/ExistingContribution-02.civibanking
+++ b/tests/resources/matcher/configuration/ExistingContribution-02.civibanking
@@ -1,0 +1,26 @@
+{
+    "plugin_type_name": "match",
+    "plugin_class_name": "matcher_contribution",
+    "name": "Existing Contribution (auto-exec below 1.0)",
+    "description": "Reconciles pending contributions automatically from probability 0.8 upwards, so several candidates can qualify.",
+    "weight": "20",
+    "config": {
+        "auto_exec": 0.8,
+        "threshold": 0.1,
+        "mode": "default",
+        "accepted_contribution_states": [
+            "Pending"
+        ],
+        "received_date_minimum": "-60 days",
+        "received_date_maximum": "+1 days",
+        "date_penalty": 0.2,
+        "request_amount_confirmation": false,
+        "payment_instrument_penalty": 0,
+        "amount_relative_minimum": 1,
+        "amount_relative_maximum": 1,
+        "amount_absolute_minimum": 0,
+        "amount_absolute_maximum": 0,
+        "amount_penalty": 1
+    },
+    "state": {}
+}


### PR DESCRIPTION
Fixes #555.

`checkAutoExecute()` iterates `$btx->getSuggestions()`, the in-memory suggestion array, and executes the first suggestion above the plugin's `auto_exec`. That array was only sorted in `saveSuggestions()`/`getSuggestionList()`, so during matching it is in insertion order — i.e. whatever order the matcher's candidate query returned. With several candidates above the threshold this executed the first (typically oldest) one instead of the most probable.

The fix keeps `$suggestion_objects` sorted in `addSuggestion()`, so the engine and the review page see the same order.

Tests (both fail on `master`):
* `CRM_Banking_BAO_BankTransactionTest::testSuggestionsAreOrderedByProbability` — suggestions added as 0.5 / 0.95 / 0.7 must iterate as 0.95 / 0.7 / 0.5.
* `CRM_Banking_Matcher_MatchContributionMatcherTest::testAutoExecutionPicksMostProbableSuggestion` — two pending contributions of the same amount (30 days ago / today) and an `ExistingContribution` matcher with `auto_exec: 0.8`: the contribution of today must be completed, the older one stay pending.