### PR TITLE
Prefix settings keys with "banking_"

### DIFF
--- a/CRM/Admin/Form/Setting/BankingSettings.php
+++ b/CRM/Admin/Form/Setting/BankingSettings.php
@@ -106,13 +106,13 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
 
     $this->add(
       'number',
-      CRM_Banking_Config::SETTING_MAX_CONTACTS_ON_LOOKUP,
+      'max_contacts_on_lookup',
       E::ts('Maximum number of contacts loaded from database on contact lookup'),
       ['min' => 1],
       TRUE
     );
     $this->addRule(
-      CRM_Banking_Config::SETTING_MAX_CONTACTS_ON_LOOKUP,
+      'max_contacts_on_lookup',
       E::ts('This needs to be a number larger than 0'),
       'positiveInteger'
     );
@@ -155,11 +155,11 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     // validate bank account references?
     $this->addElement(
       'text',
-      CRM_Banking_Config::SETTING_TRANSACTION_LIST_CUTOFF,
+      'transaction_list_cutoff',
       E::ts('Transaction limit in view')
     );
     $this->addRule(
-      CRM_Banking_Config::SETTING_TRANSACTION_LIST_CUTOFF,
+      'transaction_list_cutoff',
       E::ts('This needs to be a number larger than 0'),
       'positiveInteger'
     );
@@ -181,19 +181,19 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
    */
   public function setDefaultValues() {
     $defaults = [];
-    $defaults['new_ui']                          = Civi::settings()->get('new_ui');
-    $defaults['menu_position']                   = Civi::settings()->get('menu_position');
-    $defaults['json_editor_mode']                = Civi::settings()->get('json_editor_mode');
-    $defaults['banking_log_level']               = Civi::settings()->get('banking_log_level');
-    $defaults['banking_log_file']                = Civi::settings()->get('banking_log_file');
-    $defaults[CRM_Banking_Config::SETTING_MAX_CONTACTS_ON_LOOKUP] = CRM_Banking_Config::getMaxContactsOnLookup();
-    $defaults['reference_store_disabled']        = Civi::settings()->get('reference_store_disabled');
-    $defaults['reference_normalisation']         = Civi::settings()->get('reference_normalisation');
-    $defaults['recently_completed_cutoff']       = Civi::settings()->get('recently_completed_cutoff');
-    $defaults['reference_matching_probability']  = Civi::settings()->get('reference_matching_probability');
-    $defaults['reference_validation']            = Civi::settings()->get('reference_validation');
-    $defaults['lenient_dedupe']                  = Civi::settings()->get('lenient_dedupe');
-    $defaults[CRM_Banking_Config::SETTING_TRANSACTION_LIST_CUTOFF]
+    $defaults['new_ui'] = Civi::settings()->get('banking_new_ui');
+    $defaults['menu_position'] = Civi::settings()->get('banking_menu_position');
+    $defaults['json_editor_mode'] = Civi::settings()->get('banking_json_editor_mode');
+    $defaults['banking_log_level'] = Civi::settings()->get('banking_log_level');
+    $defaults['banking_log_file'] = Civi::settings()->get('banking_log_file');
+    $defaults['max_contacts_on_lookup'] = CRM_Banking_Config::getMaxContactsOnLookup();
+    $defaults['reference_store_disabled'] = Civi::settings()->get('banking_reference_store_disabled');
+    $defaults['reference_normalisation'] = Civi::settings()->get('banking_reference_normalisation');
+    $defaults['recently_completed_cutoff'] = Civi::settings()->get('banking_recently_completed_cutoff');
+    $defaults['reference_matching_probability'] = Civi::settings()->get('banking_reference_matching_probability');
+    $defaults['reference_validation'] = Civi::settings()->get('banking_reference_validation');
+    $defaults['lenient_dedupe'] = Civi::settings()->get('banking_lenient_dedupe');
+    $defaults['transaction_list_cutoff']
       = Civi::settings()->get(CRM_Banking_Config::SETTING_TRANSACTION_LIST_CUTOFF);
 
     if ($defaults['reference_matching_probability'] === NULL) {
@@ -210,20 +210,20 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
     $values = $this->exportValues();
 
     // process menu relevant entries
-    $old_menu_position = (int) Civi::settings()->get('menu_position');
+    $old_menu_position = (int) Civi::settings()->get('banking_menu_position');
     $new_menu_position = (int) $values['menu_position'];
 
-    $old_ui_style = (int) Civi::settings()->get('new_ui');
+    $old_ui_style = (int) Civi::settings()->get('banking_new_ui');
     $new_ui_style = (int) $values['new_ui'];
 
     if ($old_menu_position != $new_menu_position || $old_ui_style != $new_ui_style) {
-      Civi::settings()->set('new_ui', $new_ui_style);
-      Civi::settings()->set('menu_position', $new_menu_position);
+      Civi::settings()->set('banking_new_ui', $new_ui_style);
+      Civi::settings()->set('banking_menu_position', $new_menu_position);
       CRM_Core_BAO_Navigation::resetNavigation();
     }
 
     // process menu entry
-    Civi::settings()->set('json_editor_mode', $values['json_editor_mode']);
+    Civi::settings()->set('banking_json_editor_mode', $values['json_editor_mode']);
 
     // log levels
     Civi::settings()->set('banking_log_level', $values['banking_log_level']);
@@ -231,20 +231,20 @@ class CRM_Admin_Form_Setting_BankingSettings extends CRM_Core_Form {
 
     Civi::settings()->set(
       CRM_Banking_Config::SETTING_MAX_CONTACTS_ON_LOOKUP,
-      (int) $values[CRM_Banking_Config::SETTING_MAX_CONTACTS_ON_LOOKUP]
+      (int) $values['max_contacts_on_lookup']
     );
 
     // process reference normalisation / validation
-    Civi::settings()->set('reference_store_disabled', !empty($values['reference_store_disabled']));
-    Civi::settings()->set('reference_normalisation', !empty($values['reference_normalisation']));
-    Civi::settings()->set('reference_validation', !empty($values['reference_validation']));
-    Civi::settings()->set('lenient_dedupe', !empty($values['lenient_dedupe']));
-    Civi::settings()->set('reference_matching_probability', $values['reference_matching_probability']);
-    Civi::settings()->set('recently_completed_cutoff', $values['recently_completed_cutoff']);
+    Civi::settings()->set('banking_reference_store_disabled', (bool) $values['reference_store_disabled']);
+    Civi::settings()->set('banking_reference_normalisation', (bool) $values['reference_normalisation']);
+    Civi::settings()->set('banking_reference_validation', (bool) $values['reference_validation']);
+    Civi::settings()->set('banking_lenient_dedupe', (bool) $values['lenient_dedupe']);
+    Civi::settings()->set('banking_reference_matching_probability', $values['reference_matching_probability']);
+    Civi::settings()->set('banking_recently_completed_cutoff', $values['recently_completed_cutoff']);
 
     // display settings
     Civi::settings()->set(CRM_Banking_Config::SETTING_TRANSACTION_LIST_CUTOFF,
-      $values[CRM_Banking_Config::SETTING_TRANSACTION_LIST_CUTOFF]);
+      $values['transaction_list_cutoff']);
 
     // log results
     $logger = CRM_Banking_Helpers_Logger::getLogger();

--- a/CRM/Banking/BAO/BankAccount.php
+++ b/CRM/Banking/BAO/BankAccount.php
@@ -91,7 +91,7 @@ class CRM_Banking_BAO_BankAccount extends CRM_Banking_DAO_BankAccount {
    *   ordered by the reference types' order in the option group
    */
   public function getReferences() {
-    $bank_account_reference_matching_probability = Civi::settings()->get('reference_matching_probability');
+    $bank_account_reference_matching_probability = Civi::settings()->get('banking_reference_matching_probability');
     if ($bank_account_reference_matching_probability === NULL) {
       $bank_account_reference_matching_probability = 1.0;
     }

--- a/CRM/Banking/Config.php
+++ b/CRM/Banking/Config.php
@@ -24,13 +24,13 @@ class CRM_Banking_Config {
   /**
    * Setting for the transaction list cutoff
    */
-  public const SETTING_TRANSACTION_LIST_CUTOFF = 'transaction_list_cutoff';
+  public const SETTING_TRANSACTION_LIST_CUTOFF = 'banking_transaction_list_cutoff';
 
   /**
    * Setting key for the maximum number of contacts that are loaded on contact
    * lookup.
    */
-  public const SETTING_MAX_CONTACTS_ON_LOOKUP = 'max_contacts_on_lookup';
+  public const SETTING_MAX_CONTACTS_ON_LOOKUP = 'banking_max_contacts_on_lookup';
 
   /**
    * Should the bank account dedupe be done in a lenient way?
@@ -38,7 +38,7 @@ class CRM_Banking_Config {
    * @return boolean
    */
   public static function lenientDedupe() {
-    $value = Civi::settings()->get('lenient_dedupe');
+    $value = Civi::settings()->get('banking_lenient_dedupe');
     if (empty($value)) {
       return FALSE;
     }
@@ -67,7 +67,7 @@ class CRM_Banking_Config {
    *   SQL interval expression
    */
   public static function getRecentlyCompletedStatementCutoff(): string {
-    $config_setting = (int) Civi::settings()->get('recently_completed_cutoff');
+    $config_setting = (int) Civi::settings()->get('banking_recently_completed_cutoff');
     if (!empty($config_setting)) {
       return "INTERVAL {$config_setting} MONTH";
     }

--- a/CRM/Banking/Form/AccountsTab.php
+++ b/CRM/Banking/Form/AccountsTab.php
@@ -84,8 +84,8 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
     }
 
     // load settings
-    $this->assign('reference_normalisation', (int) Civi::settings()->get('reference_normalisation'));
-    $this->assign('reference_validation', (int) Civi::settings()->get('reference_validation'));
+    $this->assign('reference_normalisation', (int) Civi::settings()->get('banking_reference_normalisation'));
+    $this->assign('reference_validation', (int) Civi::settings()->get('banking_reference_validation'));
 
     // ACCOUNT REFRENCE ITEMS
     $this->add('hidden', 'contact_id', $contact_id);
@@ -100,7 +100,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
         TRUE
     );
     // set last value
-    $reference_type->setSelected(Civi::settings()->get('account.default_reference_id'));
+    $reference_type->setSelected(Civi::settings()->get('banking_account.default_reference_id'));
 
     $reference_type = $this->add(
         'text',
@@ -137,7 +137,7 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
         FALSE
     );
     // set last value
-    $country->setSelected(Civi::settings()->get('account.default_country'));
+    $country->setSelected(Civi::settings()->get('banking_account.default_country'));
 
     $this->addButtons([
       [
@@ -161,8 +161,8 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
   public function validate() {
     $error = parent::validate();
     $values = $this->exportValues();
-    $normalise = Civi::settings()->get('reference_normalisation');
-    $validate  = Civi::settings()->get('reference_validation');
+    $normalise = Civi::settings()->get('banking_reference_normalisation');
+    $validate  = Civi::settings()->get('banking_reference_validation');
 
     if (!empty($values['reference_type']) && !empty($values['reference'])) {
       if ($validate || $normalise) {
@@ -200,10 +200,10 @@ class CRM_Banking_Form_AccountsTab extends CRM_Core_Form {
 
     // save presets
     if (!empty($values['reference_type'])) {
-      Civi::settings()->set('account.default_reference_id', $values['reference_type']);
+      Civi::settings()->set('banking_account.default_reference_id', $values['reference_type']);
     }
     if (!empty($values['country'])) {
-      Civi::settings()->set('account.default_country', $values['country']);
+      Civi::settings()->set('banking_account.default_country', $values['country']);
     }
 
     // create bank account

--- a/CRM/Banking/Form/Configure.php
+++ b/CRM/Banking/Form/Configure.php
@@ -46,7 +46,7 @@ class CRM_Banking_Form_Configure extends CRM_Core_Form {
     }
 
     // set default editor mode
-    $json_editor_mode = Civi::settings()->get('json_editor_mode');
+    $json_editor_mode = Civi::settings()->get('banking_json_editor_mode');
     if (empty($json_editor_mode)) {
       $json_editor_mode = 'text';
     }

--- a/CRM/Banking/Matcher/Context.php
+++ b/CRM/Banking/Matcher/Context.php
@@ -38,7 +38,7 @@ class CRM_Banking_Matcher_Context {
     $this->btx = $btx;
     $btx->context = $this;
 
-    $this->bank_account_reference_matching_probability = Civi::settings()->get('reference_matching_probability');
+    $this->bank_account_reference_matching_probability = Civi::settings()->get('banking_reference_matching_probability');
     if ($this->bank_account_reference_matching_probability === NULL) {
       $this->bank_account_reference_matching_probability = 1.0;
     }

--- a/CRM/Banking/Page/Import.php
+++ b/CRM/Banking/Page/Import.php
@@ -132,7 +132,7 @@ class CRM_Banking_Page_Import extends CRM_Core_Page {
     }
 
     // URLs
-    $new_ui_enabled = Civi::settings()->get('new_ui');
+    $new_ui_enabled = Civi::settings()->get('banking_new_ui');
     if ($new_ui_enabled) {
       $this->assign('url_payments', CRM_Utils_System::url('civicrm/banking/statements'));
     }

--- a/CRM/Banking/Page/Review.php
+++ b/CRM/Banking/Page/Review.php
@@ -30,7 +30,7 @@ class CRM_Banking_Page_Review extends CRM_Core_Page {
   // phpcs:enable
     CRM_Core_Resources::singleton()->addStyleFile(E::LONG_NAME, 'css/banking.css');
 
-    $new_ui_enabled = Civi::settings()->get('new_ui');
+    $new_ui_enabled = Civi::settings()->get('banking_new_ui');
     // set this variable to request a redirect
     $url_redirect = NULL;
 

--- a/CRM/Banking/PluginModel/Matcher.php
+++ b/CRM/Banking/PluginModel/Matcher.php
@@ -261,7 +261,7 @@ abstract class CRM_Banking_PluginModel_Matcher extends CRM_Banking_PluginModel_B
   public function storeAccountWithContact($btx, $contact_id) {
   // phpcs:enable
     // check if this has been turned off
-    if (Civi::settings()->get('reference_store_disabled')) {
+    if (Civi::settings()->get('banking_reference_store_disabled')) {
       return;
     }
 

--- a/CRM/Banking/Upgrader.php
+++ b/CRM/Banking/Upgrader.php
@@ -50,7 +50,7 @@ class CRM_Banking_Upgrader extends CRM_Extension_Upgrader_Base {
    * @return TRUE on success
    */
   public function upgrade_0611() {
-    Civi::settings()->set('new_ui', FALSE);
+    Civi::settings()->set('banking_new_ui', FALSE);
 
     // Update order of the option group banking_tx_status.
     $statusApi = civicrm_api3(
@@ -204,7 +204,7 @@ class CRM_Banking_Upgrader extends CRM_Extension_Upgrader_Base {
       CRM_Core_Invoke::rebuildMenuAndCaches();
     }
 
-    Civi::settings()->set('reference_matching_probability', 1.0);
+    Civi::settings()->set('banking_reference_matching_probability', 1.0);
     return TRUE;
   }
 
@@ -215,7 +215,7 @@ class CRM_Banking_Upgrader extends CRM_Extension_Upgrader_Base {
    */
   public function upgrade_0800() {
     // Set the bank account reference probability to 100%.
-    Civi::settings()->set('reference_matching_probability', 1.0);
+    Civi::settings()->set('banking_reference_matching_probability', 1.0);
     return TRUE;
   }
 
@@ -291,6 +291,35 @@ class CRM_Banking_Upgrader extends CRM_Extension_Upgrader_Base {
     // update option groups
     $this->ctx->log->info('Updated options.');
     banking_civicrm_install_options(_banking_options());
+    return TRUE;
+  }
+
+  public function upgrade_0806(): bool {
+    $this->ctx->log->info('Migrate settings keys.');
+    $settingsKeys = [
+      'menu_position',
+      'new_ui',
+      'json_editor_mode',
+      'max_contacts_on_lookup',
+      'reference_store_disabled',
+      'reference_normalisation',
+      'reference_validation',
+      'lenient_dedupe',
+      'reference_matching_probability',
+      'recently_completed_cutoff',
+      'transaction_list_cutoff',
+      'account.default_reference_id',
+      'account.default_country',
+    ];
+
+    foreach ($settingsKeys as $settingsKey) {
+      $settingsValue = Civi::settings()->get($settingsKey);
+      if (NULL !== $settingsValue) {
+        Civi::settings()->set("banking_$settingsKey", $settingsValue);
+        Civi::settings()->revert($settingsKey);
+      }
+    }
+
     return TRUE;
   }
 

--- a/banking.php
+++ b/banking.php
@@ -70,7 +70,7 @@ function banking_civicrm_install() {
   banking_civicrm_install_options(_banking_options());
 
   // Set the bank account reference probability to 100%.
-  Civi::settings()->set('reference_matching_probability', 1.0);
+  Civi::settings()->set('banking_reference_matching_probability', 1.0);
 
   _banking_civix_civicrm_install();
 }
@@ -218,7 +218,7 @@ function banking_civicrm_entityTypes(&$entityTypes) {
  */
 function banking_civicrm_navigationMenu(&$menu) {
   // check if we want the menu to be built at all
-  $menu_position = (int) Civi::settings()->get('menu_position');
+  $menu_position = (int) Civi::settings()->get('banking_menu_position');
   switch ($menu_position) {
     case 2:
       // menu is off, see CRM_Admin_Form_Setting_BankingSettings
@@ -241,7 +241,7 @@ function banking_civicrm_navigationMenu(&$menu) {
 
   // Determine the url for the statements/payments (new ui or old ui).
   $statementUrl = 'civicrm/banking/statements';
-  if (!Civi::settings()->get('new_ui')) {
+  if (!Civi::settings()->get('banking_new_ui')) {
     $statementUrl = 'civicrm/banking/payments';
   }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,12 +7,6 @@ parameters:
 			path: CRM/Admin/Form/Setting/BankingSettings.php
 
 		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
-			count: 4
-			path: CRM/Admin/Form/Setting/BankingSettings.php
-
-		-
 			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
 			identifier: notEqual.notAllowed
 			count: 2


### PR DESCRIPTION
As mentioned in #551 there were some very generic settings keys. Because settings are global keys should be prepended by an extension specific prefix. This PR adds `banking_` as prefix to all settings keys.