### PR TITLE
Revert removal of `require_once 'banking_options.php'`

### DIFF
--- a/banking.php
+++ b/banking.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 
 // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
 require_once 'banking.civix.php';
+require_once 'banking_options.php';
 // phpcs:enable
 
 use Civi\Banking\DependencyInjection\Compiler\ActionProviderPass;


### PR DESCRIPTION
Follow-up of #554.

Until `banking_civicrm_install_options()` isn't removed it has to available for use in other extensions.